### PR TITLE
Fixes NullReferenceException and renames Initialized bool as IsLoading.

### DIFF
--- a/BassClefStudio.NET.Sync/BassClefStudio.NET.Sync.csproj
+++ b/BassClefStudio.NET.Sync/BassClefStudio.NET.Sync.csproj
@@ -6,7 +6,7 @@
     <RepositoryUrl>https://github.com/bassclefstudio/.Net-Libraries.git</RepositoryUrl>
     <Description>A library for managing the connection between data stores (web APIs, files) and .NET objects.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.4.2</Version>
+    <Version>1.4.3</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/.Net-Libraries</PackageProjectUrl>
   </PropertyGroup>
 

--- a/BassClefStudio.NET.Sync/ISyncItem.cs
+++ b/BassClefStudio.NET.Sync/ISyncItem.cs
@@ -19,9 +19,9 @@ namespace BassClefStudio.NET.Sync
         T Item { get; set; }
 
         /// <summary>
-        /// A <see cref="bool"/> indicating whether the <see cref="Item"/> has been initialized from the source.
+        /// A <see cref="bool"/> indicating whether the <see cref="Item"/> is currently being updated from the source.
         /// </summary>
-        bool Initialized { get; }
+        bool IsLoading { get; }
 
         /// <summary>
         /// Updates <see cref="Item"/> with the latest content from the data source.

--- a/BassClefStudio.NET.Sync/SyncItem.cs
+++ b/BassClefStudio.NET.Sync/SyncItem.cs
@@ -6,16 +6,24 @@ using System.Threading.Tasks;
 
 namespace BassClefStudio.NET.Sync
 {
+    /// <summary>
+    /// A base class for <see cref="ISyncItem{T}"/> that supports syncing using a single <see cref="ILink{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of item to sync.</typeparam>
     public class SyncItem<T> : Observable, ISyncItem<T>
     {
         private T item;
         /// <inheritdoc/>
         public T Item { get => item; set { Set(ref item, value); ItemChanged?.Invoke(this, new EventArgs()); } }
 
+        /// <summary>
+        /// An event that is called when the <see cref="Item"/> property is changed.
+        /// </summary>
         public event EventHandler ItemChanged;
 
+        private bool isLoading;
         /// <inheritdoc/>
-        public bool Initialized => Item != null;
+        public bool IsLoading { get => isLoading; set => Set(ref isLoading, value); }
 
         /// <summary>
         /// The <see cref="ILink{T}"/> to the data store.
@@ -40,31 +48,50 @@ namespace BassClefStudio.NET.Sync
         public SyncItem(ILink<T> link = null)
         {
             Link = link;
+            IsLoading = true;
         }
 
         /// <inheritdoc/>
         public async Task UpdateAsync(ISyncInfo<T> info = null)
         {
+            IsLoading = true;
             await Link.UpdateAsync(this, info);
+            IsLoading = false;
         }
 
         /// <inheritdoc/>
         public async Task PushAsync(ISyncInfo<T> info = null)
         {
+            IsLoading = true;
             await Link.PushAsync(this, info);
+            IsLoading = false;
         }
     }
 
+    /// <summary>
+    /// A <see cref="SyncItem{T}"/> that supports keyed <see cref="IIdentifiable{T}"/> values for <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of item being synced.</typeparam>
+    /// <typeparam name="TKey">The key which <typeparamref name="T"/> implements as an <see cref="IIdentifiable{T}"/>.</typeparam>
     public class KeyedSyncItem<T, TKey> : SyncItem<T>, IKeyedSyncItem<T, TKey> where T : IIdentifiable<TKey> where TKey : IEquatable<TKey>
     {
         /// <inheritdoc/>
         public TKey Id { get; private set; }
 
+        /// <summary>
+        /// Creates a new <see cref="KeyedSyncItem{T, TKey}"/>
+        /// </summary>
+        /// <param name="item">The currently cached or created <typeparamref name="T"/> item.</param>
+        /// <param name="link">An <see cref="ILink{T}"/> connecting this <see cref="SyncItem{T}"/> to a remote data source.</param>
         public KeyedSyncItem(T item, ILink<T> link = null) : base(item, link)
         {
             ItemChanged += KeyedItemChanged;
         }
 
+        /// <summary>
+        /// Creates a new <see cref="KeyedSyncItem{T, TKey}"/>
+        /// </summary>
+        /// <param name="link">An <see cref="ILink{T}"/> connecting this <see cref="SyncItem{T}"/> to a remote data source.</param>
         public KeyedSyncItem(ILink<T> link = null) : base(link)
         {
             ItemChanged += KeyedItemChanged;


### PR DESCRIPTION
Fixes #32 - null reference checks are added and a constructor for `SyncCollection<TItem, TKey>`. In addition the `ISyncItem<T>.Initialized` was renamed `IsLoading` to accompany new functionality.