### PR TITLE
Added generic parameter T, CreateSyncItem to SyncCollection

### DIFF
--- a/BassClefStudio.NET.Sync/BassClefStudio.NET.Sync.csproj
+++ b/BassClefStudio.NET.Sync/BassClefStudio.NET.Sync.csproj
@@ -6,7 +6,7 @@
     <RepositoryUrl>https://github.com/bassclefstudio/.Net-Libraries.git</RepositoryUrl>
     <Description>A library for managing the connection between data stores (web APIs, files) and .NET objects.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.4.3</Version>
+    <Version>1.4.4</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/.Net-Libraries</PackageProjectUrl>
   </PropertyGroup>
 


### PR DESCRIPTION
`CreateSyncItem()` allows adding strongly typed items of type `T` to the collection (for binding purposes and such). Related to #34.