### PR TITLE
Improvements to binding and generic parameters

### DIFF
--- a/BassClefStudio.NET.Sync/BassClefStudio.NET.Sync.csproj
+++ b/BassClefStudio.NET.Sync/BassClefStudio.NET.Sync.csproj
@@ -6,7 +6,7 @@
     <RepositoryUrl>https://github.com/bassclefstudio/.Net-Libraries.git</RepositoryUrl>
     <Description>A library for managing the connection between data stores (web APIs, files) and .NET objects.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.4.4</Version>
+    <Version>1.5.0</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/.Net-Libraries</PackageProjectUrl>
   </PropertyGroup>
 

--- a/BassClefStudio.NET.Sync/ISyncItem.cs
+++ b/BassClefStudio.NET.Sync/ISyncItem.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -11,7 +12,7 @@ namespace BassClefStudio.NET.Sync
     /// Represents an object of type <typeparamref name="T"/> cached locally and synced with a remote data source (such as an API, file, or database).
     /// </summary>
     /// <typeparam name="T">The type of the item to sync.</typeparam>
-    public interface ISyncItem<T>
+    public interface ISyncItem<T> : INotifyPropertyChanged
     {
         /// <summary>
         /// The locally cached <typeparamref name="T"/> item.
@@ -33,7 +34,6 @@ namespace BassClefStudio.NET.Sync
         /// </summary>
         Task PushAsync(ISyncInfo<T> info = null);
     }
-
 
     public interface IKeyedSyncItem<T, TKey> : ISyncItem<T>, IIdentifiable<TKey> where T : IIdentifiable<TKey> where TKey : IEquatable<TKey>
     { }

--- a/BassClefStudio.NET.Sync/SyncCollection.cs
+++ b/BassClefStudio.NET.Sync/SyncCollection.cs
@@ -23,25 +23,24 @@ namespace BassClefStudio.NET.Sync
     /// <summary>
     /// Represents a synced keyed <see cref="ISyncCollection{T}"/> of <see cref="ISyncItem{T}"/>s of type <typeparamref name="TItem"/>.
     /// </summary>
-    /// <typeparam name="T">The type of items in the collection. This must inherit from <see cref="IKeyedSyncItem{T, TKey}"/> to support required syncing of items and getting/setting by key.</typeparam>
     /// <typeparam name="TItem">The type of items in the collection.</typeparam>
     /// <typeparam name="TKey">The type of the key used to sync each item in the collection.</typeparam>
-    public abstract class SyncCollection<T, TItem, TKey> : Observable, ISyncCollection<T> where T : IKeyedSyncItem<TItem, TKey> where TItem : IIdentifiable<TKey> where TKey : IEquatable<TKey>
+    public abstract class SyncCollection<TItem, TKey> : Observable, ISyncCollection<IKeyedSyncItem<TItem, TKey>> where TItem : IIdentifiable<TKey> where TKey : IEquatable<TKey>
     {
-        private ObservableCollection<T> item;
+        private ObservableCollection<IKeyedSyncItem<TItem, TKey>> item;
         /// <inheritdoc/>
-        public ObservableCollection<T> Item { get => item; set => Set(ref item, value); }
+        public ObservableCollection<IKeyedSyncItem<TItem, TKey>> Item { get => item; set => Set(ref item, value); }
 
         private bool isLoading;
         /// <inheritdoc/>
         public bool IsLoading { get => isLoading; set => Set(ref isLoading, value); }
 
         /// <summary>
-        /// Creates a new empty <see cref="SyncCollection{T, TItem, TKey}"/>.
+        /// Creates a new empty <see cref="SyncCollection{TItem, TKey}"/>.
         /// </summary>
         public SyncCollection()
         {
-            Item = new ObservableCollection<T>();
+            Item = new ObservableCollection<IKeyedSyncItem<TItem, TKey>>();
         }
 
         /// <summary>
@@ -56,19 +55,19 @@ namespace BassClefStudio.NET.Sync
         protected abstract Task<ISyncCollectionInfo<TItem, TKey>> GetCollectionInfo();
 
         /// <summary>
-        /// Creates a <typeparamref name="T"/> item to populate a new item in the collection.
+        /// Creates an <see cref="IKeyedSyncItem{TItem, TKey}"/> item to populate a new item in the collection.
         /// </summary>
         /// <param name="link">The <see cref="ILink{T}"/> created for the syncing of the item.</param>
-        protected abstract T CreateSyncItem(ILink<TItem> link);
+        protected abstract IKeyedSyncItem<TItem, TKey> CreateSyncItem(ILink<TItem> link);
 
         /// <inheritdoc/>
-        public async Task UpdateAsync(ISyncInfo<ObservableCollection<T>> info = null)
+        public async Task UpdateAsync(ISyncInfo<ObservableCollection<IKeyedSyncItem<TItem, TKey>>> info = null)
         {
             IsLoading = true;
             var collectionInfo = await GetCollectionInfo();
             if(Item == null)
             {
-                Item = new ObservableCollection<T>();
+                Item = new ObservableCollection<IKeyedSyncItem<TItem, TKey>>();
             }
             Item.Sync(collectionInfo.GetKeys(), i => CreateSyncItem(GetLink(i)));
             await Item.Select(i => i.UpdateAsync(collectionInfo)).RunParallelAsync();
@@ -76,7 +75,7 @@ namespace BassClefStudio.NET.Sync
         }
 
         /// <inheritdoc/>
-        public async Task PushAsync(ISyncInfo<ObservableCollection<T>> info = null)
+        public async Task PushAsync(ISyncInfo<ObservableCollection<IKeyedSyncItem<TItem, TKey>>> info = null)
         {
             IsLoading = true;
             if (info is ISyncInfo<TItem> syncInfo)


### PR DESCRIPTION
Removed unnecessary generic parameter from `SyncCollection<TItem, TKey>` and added `INotifyPropertyChanged` requirement to `ISyncItem<T>`. Should improve binding issues and skepticism on the third generic parameter for `SyncCollection` brought up in #34. 