### PR TITLE
Removed forced dependency of ISyncCollection<T> with ObservableCollection<T>

### DIFF
--- a/BassClefStudio.NET.Sync/BassClefStudio.NET.Sync.csproj
+++ b/BassClefStudio.NET.Sync/BassClefStudio.NET.Sync.csproj
@@ -6,7 +6,7 @@
     <RepositoryUrl>https://github.com/bassclefstudio/.Net-Libraries.git</RepositoryUrl>
     <Description>A library for managing the connection between data stores (web APIs, files) and .NET objects.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.5.0</Version>
+    <Version>1.5.1</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/.Net-Libraries</PackageProjectUrl>
   </PropertyGroup>
 

--- a/BassClefStudio.NET.Sync/ISyncItem.cs
+++ b/BassClefStudio.NET.Sync/ISyncItem.cs
@@ -38,6 +38,6 @@ namespace BassClefStudio.NET.Sync
     public interface IKeyedSyncItem<T, TKey> : ISyncItem<T>, IIdentifiable<TKey> where T : IIdentifiable<TKey> where TKey : IEquatable<TKey>
     { }
 
-    public interface ISyncCollection<T> : ISyncItem<ObservableCollection<T>>
+    public interface ISyncCollection<T> : ISyncItem<IList<T>>
     { }
 }


### PR DESCRIPTION
Fixes #39 by allowing constructor of `SyncCollection<TItem, TKey>` to specify a custom initialization function to create collections other than `ObservableCollection<T>` (for binding issues related to #34).