### PR TITLE
v1.4.2 - RunSynchronously() and collection extensions

### DIFF
--- a/BassClefStudio.NET.Core/BassClefStudio.NET.Core.csproj
+++ b/BassClefStudio.NET.Core/BassClefStudio.NET.Core.csproj
@@ -7,7 +7,7 @@
     <Company>BassClefStudio</Company>
     <Description>Contains helper classes and extension methods for creating .NET projects.</Description>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>1.4.0</Version>
+    <Version>1.4.2</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageProjectUrl>https://github.com/bassclefstudio/.Net-Libraries</PackageProjectUrl>
   </PropertyGroup>

--- a/BassClefStudio.NET.Core/CollectionExtensions.cs
+++ b/BassClefStudio.NET.Core/CollectionExtensions.cs
@@ -5,6 +5,9 @@ using System.Linq;
 
 namespace BassClefStudio.NET.Core
 {
+    /// <summary>
+    /// A class containing extension methods for <see cref="IList{T}"/> and <see cref="IEnumerable{T}"/>.
+    /// </summary>
     public static class CollectionExtensions
     {
         #region RangeActions
@@ -99,6 +102,30 @@ namespace BassClefStudio.NET.Core
         /// <summary>
         /// Synchronizes the items of an <see cref="IList{T}"/> with the items in another <see cref="IEnumerable{T}"/> by adding and removing related items.
         /// </summary>
+        /// <typeparam name="T">The type of items in both collections.</typeparam>
+        /// <typeparam name="TKey">The type of the items' <see cref="IIdentifiable{T}.Id"/>.</typeparam>
+        /// <param name="list">This <see cref="IList{T}"/>, which will be synchronized.</param>
+        /// <param name="newData">A collection of new data to use to update <paramref name="list"/>.</param>
+        /// <param name="isDestructive">A <see cref="bool"/> indicating if items should be removed from <paramref name="list"/> if they do not occur in <paramref name="newData"/>.</param>
+        public static void Sync<T, TKey>(this IList<T> list, IEnumerable<T> newData, bool isDestructive = true) where T : IIdentifiable<TKey> where TKey : IEquatable<TKey>
+            => Sync(list, newData, (a, b) => a.Id.Equals(b.Id), isDestructive);
+
+        /// <summary>
+        /// Synchronizes the items of an <see cref="IList{T}"/> with the items in another <see cref="IEnumerable{T}"/> by adding and removing related items.
+        /// </summary>
+        /// <typeparam name="T1">The type of the items in <paramref name="list"/>.</typeparam>
+        /// <typeparam name="T2">The type of the items in <paramref name="newData"/>.</typeparam>
+        /// <typeparam name="TKey">The type of the items' <see cref="IIdentifiable{T}.Id"/>.</typeparam>
+        /// <param name="list">This <see cref="IList{T}"/>, which will be synchronized.</param>
+        /// <param name="newData">A collection of new data to use to update <paramref name="list"/>.</param>
+        /// <param name="createFunc">A function that, given the item of type <typeparamref name="T2"/> in the <paramref name="newData"/>, creates a new item of type <typeparamref name="T1"/> to include in <paramref name="list"/>.</param>
+        /// <param name="isDestructive">A <see cref="bool"/> indicating if items should be removed from <paramref name="list"/> if they do not occur in <paramref name="newData"/>.</param>
+        public static void Sync<T1, T2, TKey>(this IList<T1> list, IEnumerable<T2> newData, Func<T2, T1> createFunc, bool isDestructive = true) where T1 : IIdentifiable<TKey> where T2 : IIdentifiable<TKey> where TKey : IEquatable<TKey>
+            => Sync(list, newData, (a, b) => a.Id.Equals(b.Id), createFunc, isDestructive);
+
+        /// <summary>
+        /// Synchronizes the items of an <see cref="IList{T}"/> with the items in another <see cref="IEnumerable{T}"/> by adding and removing related items.
+        /// </summary>
         /// <typeparam name="T1">The type of the items in <paramref name="list"/>.</typeparam>
         /// <typeparam name="T2">The type of the items in <paramref name="newData"/>.</typeparam>
         /// <param name="list">This <see cref="IList{T}"/>, which will be synchronized.</param>
@@ -106,7 +133,7 @@ namespace BassClefStudio.NET.Core
         /// <param name="equalityFunc">A function that returns a <see cref="bool"/> indicating whether an item of type <typeparamref name="T1"/> and an item of type <typeparamref name="T2"/> are equal for the purposes of the operation.</param>
         /// <param name="createFunc">A function that, given the item of type <typeparamref name="T2"/> in the <paramref name="newData"/>, creates a new item of type <typeparamref name="T1"/> to include in <paramref name="list"/>.</param>
         /// <param name="isDestructive">A <see cref="bool"/> indicating if items should be removed from <paramref name="list"/> if they do not occur in <paramref name="newData"/>.</param>
-        public static void Sync<T1, T2>(this IList<T1> list, IEnumerable<T2> newData, Func<T1, T2, bool> equalityFunc, Func<T2, T1> createFunc = null, bool isDestructive = true)
+        public static void Sync<T1, T2>(this IList<T1> list, IEnumerable<T2> newData, Func<T1, T2, bool> equalityFunc, Func<T2, T1> createFunc, bool isDestructive = true)
         {
             var toAdd = newData.Where(d => !list.Any(i => GetEqualityFunc(equalityFunc)(i, d))).ToList();
             if (isDestructive)
@@ -120,32 +147,7 @@ namespace BassClefStudio.NET.Core
                 list.AddRange(toAdd.Select(a => createFunc(a)));
             }
         }
-      
-        /// <summary>
-        /// Synchronizes the items of an <see cref="IList{T}"/> with the items in another <see cref="IEnumerable{T}"/> by adding and removing related items, using <see cref="IIdentifiable{T}"/> as the means of determining equality.
-        /// </summary>
-        /// <typeparam name="T1">The type of the items in <paramref name="list"/>.</typeparam>
-        /// <typeparam name="T2">The type of the items in <paramref name="newData"/>.</typeparam>
-        /// <typeparam name="TKey">The type of the unique key between the two <see cref="IIdentifiable{T}"/> collections of types <typeparamref name="T1"/> and <typeparamref name="T2"/>.</typeparam>
-        /// <param name="list">This <see cref="IList{T}"/>, which will be synchronized.</param>
-        /// <param name="newData">A collection of new data to use to update <paramref name="list"/>.</param>
-        /// <param name="replaceFunc">A function that, given the item of type <typeparamref name="T2"/> in the <paramref name="newData"/>, creates a new item of type <typeparamref name="T1"/> to include in <paramref name="list"/>.</param>
-        /// <param name="isDestructive">A <see cref="bool"/> indicating if items should be removed from <paramref name="list"/> if they do not occur in <paramref name="newData"/>.</param>
-        public static void Sync<T1, T2, TKey>(this IList<T1> list, IEnumerable<T2> newData, Func<T2, T1> createFunc = null, bool isDestructive = true) where T1 : IIdentifiable<TKey> where T2 : IIdentifiable<TKey> where TKey : IEquatable<TKey>
-         => Sync(list, newData, (t1, t2) => t1.Id.Equals(t2.Id), createFunc, isDestructive);
 
-        /// <summary>
-        /// Synchronizes the items of an <see cref="IList{T}"/> with the items in another <see cref="IEnumerable{T}"/> by adding and removing related items, using <see cref="IIdentifiable{T}"/> as the means of determining equality.
-        /// </summary>
-        /// <typeparam name="T1">The type of the items in <paramref name="list"/>.</typeparam>
-        /// <typeparam name="TKey">The type of the items in <paramref name="newData"/> and <see cref="IIdentifiable{T}.Id"/> of type <typeparamref name="T1"/>.</typeparam>
-        /// <param name="list">This <see cref="IList{T}"/>, which will be synchronized.</param>
-        /// <param name="newData">A collection of new data to use to update <paramref name="list"/>.</param>
-        /// <param name="replaceFunc">A function that, given the item of type <typeparamref name="T2"/> in the <paramref name="newData"/>, creates a new item of type <typeparamref name="T1"/> to include in <paramref name="list"/>.</param>
-        /// <param name="isDestructive">A <see cref="bool"/> indicating if items should be removed from <paramref name="list"/> if they do not occur in <paramref name="newData"/>.</param>
-        public static void Sync<T1, TKey>(this IList<T1> list, IEnumerable<TKey> newData, Func<TKey, T1> createFunc = null, bool isDestructive = true) where T1 : IIdentifiable<TKey> where TKey : IEquatable<TKey>
-         => Sync(list, newData, (t1, t2) => t1.Id.Equals(t2), createFunc, isDestructive);
-      
         #endregion
         #region Grouping
 

--- a/BassClefStudio.NET.Core/SynchronousTask.cs
+++ b/BassClefStudio.NET.Core/SynchronousTask.cs
@@ -141,9 +141,9 @@ namespace BassClefStudio.NET.Core
     }
 
     /// <summary>
-    /// Contains extension methods for awaiting collections of <see cref="Task"/>s.
+    /// Contains extension methods for running <see cref="Task"/>s.
     /// </summary>
-    public static class ParallelTaskExtensions
+    public static class TaskExtensions
     {
         /// <summary>
         /// Starts and awaits a collection of <see cref="Task"/>s in parallel.
@@ -182,6 +182,18 @@ namespace BassClefStudio.NET.Core
             }
 
             return results;
+        }
+
+        /// <summary>
+        /// Starts the <see cref="Task"/> on a new thread asynchronously in a try/catch block to catch <see cref="Exception"/>s (for more info, see <see cref="SynchronousTask"/>).
+        /// </summary>
+        /// <param name="task">The function returning a <see cref="Task"/> to start.</param>
+        /// <param name="exceptionAction">The action to take if the <see cref="Task"/> throws an <see cref="Exception"/>. Defaults to <see cref="SynchronousTask.DefaultExceptionAction(Exception)"/>.</param>
+        /// <param name="isLocked">A <see cref="bool"/> value indicating whether multiple calls to a <see cref="SynchronousTask.RunTaskAsync"/> or <see cref="SynchronousTask.RunTask"/> method while the task is running will use the same instance of the task (true), or create a different instance each time (false).</param>
+        public static void RunSynchronously(this Func<Task> task, Action<Exception> exceptionAction = null, bool isLocked = false)
+        {
+            SynchronousTask runTask = new SynchronousTask(task, exceptionAction, isLocked);
+            _ = runTask.RunTask();
         }
     }
 }

--- a/BassClefStudio.NET.Sync/BassClefStudio.NET.Sync.csproj
+++ b/BassClefStudio.NET.Sync/BassClefStudio.NET.Sync.csproj
@@ -6,7 +6,7 @@
     <RepositoryUrl>https://github.com/bassclefstudio/.Net-Libraries.git</RepositoryUrl>
     <Description>A library for managing the connection between data stores (web APIs, files) and .NET objects.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.5.1</Version>
+    <Version>1.5.2</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/.Net-Libraries</PackageProjectUrl>
   </PropertyGroup>
 

--- a/BassClefStudio.NET.Sync/SyncCollection.cs
+++ b/BassClefStudio.NET.Sync/SyncCollection.cs
@@ -74,7 +74,7 @@ namespace BassClefStudio.NET.Sync
             {
                 Item = InitList();
             }
-            Item.Sync(collectionInfo.GetKeys(), i => CreateSyncItem(GetLink(i)));
+            Item.Sync(collectionInfo.GetKeys(), (a, b) => a.Id.Equals(b), i => CreateSyncItem(GetLink(i)));
             await Item.Select(i => i.UpdateAsync(collectionInfo)).RunParallelAsync();
             IsLoading = false;
         }


### PR DESCRIPTION
Added new versions of the `Sync()` extension method that automatically use the `IIdentifiable.Id` equality comparer (this was there but hidden b/c of irrelevant optional parameters). In addition, added a new `RunSynchronously()` extension method that does the creation of the `SynchronousTask` for you, and runs the task, in one method on a `Func<Task>`.