### PR TITLE
v1.5 - Adds Color and DateTimeSpan to the Primitives namespace.

### DIFF
--- a/BassClefStudio.NET.Core/BassClefStudio.NET.Core.csproj
+++ b/BassClefStudio.NET.Core/BassClefStudio.NET.Core.csproj
@@ -7,7 +7,7 @@
     <Company>BassClefStudio</Company>
     <Description>Contains helper classes and extension methods for creating .NET projects.</Description>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>1.4.2</Version>
+    <Version>1.5.0</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageProjectUrl>https://github.com/bassclefstudio/.Net-Libraries</PackageProjectUrl>
   </PropertyGroup>

--- a/BassClefStudio.NET.Core/Primitives/Color.cs
+++ b/BassClefStudio.NET.Core/Primitives/Color.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BassClefStudio.NET.Core.Primitives
+{
+    /// <summary>
+    /// Represents a color in RGBA space.
+    /// </summary>
+    public struct Color
+    {
+        /// <summary>
+        /// The red <see cref="byte"/>.
+        /// </summary>
+        public byte R { get; }
+
+        /// <summary>
+        /// The green <see cref="byte"/>.
+        /// </summary>
+        public byte G { get; }
+
+        /// <summary>
+        /// The blue <see cref="byte"/>.
+        /// </summary>
+        public byte B { get; }
+
+        /// <summary>
+        /// The alpha (transparency) <see cref="byte"/>.
+        /// </summary>
+        public byte A { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="Color"/> value.
+        /// </summary>
+        /// <param name="r">The red <see cref="byte"/>.</param>
+        /// <param name="g">The green <see cref="byte"/>.</param>
+        /// <param name="b">The blue <see cref="byte"/>.</param>
+        /// <param name="a">The alpha (transparency) <see cref="byte"/>. Defaults to 255 (opaque).</param>
+        public Color(byte r, byte g, byte b, byte a = 255)
+        {
+            R = r;
+            G = g;
+            B = b;
+            A = a;
+        }
+    }
+}

--- a/BassClefStudio.NET.Core/Primitives/DateTimeSpan.cs
+++ b/BassClefStudio.NET.Core/Primitives/DateTimeSpan.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace BassClefStudio.NET.Core.Time
+namespace BassClefStudio.NET.Core.Primitives
 {
     /// <summary>
     /// Represents a contiguous block of time between two <see cref="DateTimeOffset"/>s.


### PR DESCRIPTION
The `BassClefStudio.NET.Core.Primitives` namespace provides a space for adding additional .NET Standard value/base types not part of the BCL. `Color` and `DateTimeSpan` are the first two types to be added, in version `v1.5.0` of the Nuget package.