### PR TITLE
DateTimeZone Patch

### DIFF
--- a/BassClefStudio.NET.Core/BassClefStudio.NET.Core.csproj
+++ b/BassClefStudio.NET.Core/BassClefStudio.NET.Core.csproj
@@ -7,7 +7,7 @@
     <Company>BassClefStudio</Company>
     <Description>Contains helper classes and extension methods for creating .NET projects.</Description>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>1.5.2</Version>
+    <Version>1.5.3</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageProjectUrl>https://github.com/bassclefstudio/.Net-Libraries</PackageProjectUrl>
   </PropertyGroup>

--- a/BassClefStudio.NET.Core/Primitives/DateTimeZone.cs
+++ b/BassClefStudio.NET.Core/Primitives/DateTimeZone.cs
@@ -7,7 +7,7 @@ namespace BassClefStudio.NET.Core.Primitives
     /// <summary>
     /// Represents a <see cref="DateTime"/> with knowledge of the time zone it belongs to.
     /// </summary>
-    public struct DateTimeZone : IComparable, IComparable<DateTimeOffset>, IEquatable<DateTimeOffset>, IComparable<DateTimeZone>, IEquatable<DateTimeZone>
+    public struct DateTimeZone : IComparable, IComparable<DateTimeOffset>, IEquatable<DateTimeOffset>, IComparable<DateTimeZone>, IEquatable<DateTimeZone>, IFormattable
     {
         /// <summary>
         /// The date-time of this <see cref="DateTimeZone"/>, with no time-zone information attached.
@@ -130,6 +130,12 @@ namespace BassClefStudio.NET.Core.Primitives
         public override string ToString()
         {
             return $"{DateTime} ({TimeZone})";
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider = null)
+        {
+            return $"{DateTime.ToString(format, formatProvider)} ({TimeZone})";
         }
 
         /// <summary>

--- a/BassClefStudio.NET.Core/Primitives/DateTimeZone.cs
+++ b/BassClefStudio.NET.Core/Primitives/DateTimeZone.cs
@@ -126,6 +126,12 @@ namespace BassClefStudio.NET.Core.Primitives
             return base.GetHashCode();
         }
 
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return $"{DateTime} ({TimeZone})";
+        }
+
         /// <summary>
         /// Checks if two <see cref="DateTimeZone"/>s represent the same point in time and time-zone.
         /// </summary>


### PR DESCRIPTION
Added `ToString()` method and `IFormattable` implementation (calls `DateTime.ToString()`), missing on initial release of the type.