### PR TITLE
Added the IStream interface and derived classes (excluding commands)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,4 +26,4 @@ jobs:
     - name: Build
       run: dotnet build --configuration Release --no-restore
     - name: Test
-      run: dotnet test --no-restore --verbosity normal
+      run: dotnet test ./BassClefStudio.NET.Tests/BassClefStudio.NET.Tests.csproj --no-restore --verbosity normal

--- a/BassClefStudio.NET.Core/BassClefStudio.NET.Core.csproj
+++ b/BassClefStudio.NET.Core/BassClefStudio.NET.Core.csproj
@@ -1,14 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RepositoryUrl>https://github.com/bassclefstudio/.Net-Libraries.git</RepositoryUrl>
     <Authors>BassClefStudio</Authors>
     <Company>BassClefStudio</Company>
     <Description>Contains helper classes and extension methods for creating .NET projects.</Description>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>1.6.1</Version>
+    <Version>2.0.0</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageProjectUrl>https://github.com/bassclefstudio/.Net-Libraries</PackageProjectUrl>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="Streams\" />
+  </ItemGroup>
 </Project>

--- a/BassClefStudio.NET.Core/Streams/ChildStreams.cs
+++ b/BassClefStudio.NET.Core/Streams/ChildStreams.cs
@@ -1,0 +1,144 @@
+﻿using BassClefStudio.NET.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BassClefStudio.NET.Core.Streams
+{
+    /// <summary>
+    /// Represents a basic <see cref="IStream{T}"/> that transforms the returned values from another parent <see cref="IStream{T}"/>, one-to-one, in their initial order.
+    /// </summary>
+    /// <typeparam name="T1">The type of values returned by the parent <see cref="IStream{T}"/>.</typeparam>
+    /// <typeparam name="T2">The type of the transformed values this <see cref="IStream{T}"/> returns.</typeparam>
+    public abstract class ChildStream<T1, T2> : IStream<T2>
+    {
+        /// <inheritdoc/>
+        public bool Started { get; private set; } = false;
+
+        /// <inheritdoc/>
+        public event EventHandler<StreamValue<T2>> ValueEmitted;
+
+        /// <summary>
+        /// The parent <see cref="IStream{T}"/> this <see cref="ChildStream{T1, T2}"/> is based on.
+        /// </summary>
+        public IStream<T1> ParentStream { get; }
+
+        /// <summary>
+        /// A method that takes a <typeparamref name="T1"/> object and produces a <typeparamref name="T2"/> object.
+        /// </summary>
+        /// <param name="input">The input <typeparamref name="T1"/> from <see cref="ParentStream"/>.</param>
+        protected abstract T2 ProduceValue(T1 input);
+
+        /// <summary>
+        /// Creates a new <see cref="ChildStream{T1, T2}"/> from the 
+        /// </summary>
+        /// <param name="parent"></param>
+        public ChildStream(IStream<T1> parent)
+        {
+            ParentStream = parent;
+        }
+
+        /// <inheritdoc/>
+        public void Start()
+        {
+            if (!Started)
+            {
+                Started = true;
+                ParentStream.ValueEmitted += ParentValueEmitted;
+                ParentStream.Start();
+            }
+        }
+
+        private void ParentValueEmitted(object sender, StreamValue<T1> e)
+        {
+            if (e.DataType == StreamValueType.Completed)
+            {
+                ValueEmitted?.Invoke(this, new StreamValue<T2>());
+            }
+            else if (e.DataType == StreamValueType.Error)
+            {
+                ValueEmitted?.Invoke(this, new StreamValue<T2>(e.Error));
+            }
+            else if (e.DataType == StreamValueType.Result)
+            {
+                try
+                {
+                    var output = ProduceValue(e.Result);
+                    ValueEmitted?.Invoke(this, new StreamValue<T2>(output));
+                }
+                catch (Exception ex)
+                {
+                    ValueEmitted?.Invoke(this, new StreamValue<T2>(ex));
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// An <see cref="IStream{T}"/>/<see cref="ChildStream{T1, T2}"/> that maps each <typeparamref name="T1"/> value from the parent stream into a <typeparamref name="T2"/> value via a given function.
+    /// </summary>
+    /// <typeparam name="T1">The type of values returned by the parent <see cref="IStream{T}"/>.</typeparam>
+    /// <typeparam name="T2">The type of the transformed values this <see cref="IStream{T}"/> returns.</typeparam>
+    public class MapStream<T1, T2> : ChildStream<T1, T2>
+    {
+        /// <summary>
+        /// The function for converting each <typeparamref name="T1"/> item to its <typeparamref name="T2"/> representation.
+        /// </summary>
+        public Func<T1, T2> ProduceFunc { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="MapStream{T1, T2}"/>.
+        /// </summary>
+        /// <param name="parent">The parent <see cref="IStream{T}"/> producing <typeparamref name="T1"/> values.</param>
+        /// <param name="mapFunc">The function for converting each <typeparamref name="T1"/> item to its <typeparamref name="T2"/> representation.</param>
+        public MapStream(IStream<T1> parent, Func<T1, T2> mapFunc) : base(parent)
+        {
+            ProduceFunc = mapFunc;
+        }
+
+        /// <inheritdoc/>
+        protected override T2 ProduceValue(T1 input)
+        {
+            return ProduceFunc(input);
+        }
+    }
+
+    /// <summary>
+    /// An <see cref="IStream{T}"/>/<see cref="ChildStream{T1, T2}"/> that aggregates incoming <typeparamref name="T1"/> values from the parent stream into a <typeparamref name="T2"/> <see cref="CurrentState"/>.
+    /// </summary>
+    /// <typeparam name="T1">The type of values returned by the parent <see cref="IStream{T}"/>.</typeparam>
+    /// <typeparam name="T2">The type of the transformed values this <see cref="IStream{T}"/> returns.</typeparam>
+    public class AggregateStream<T1, T2> : ChildStream<T1, T2>
+    {
+        /// <summary>
+        /// A <typeparamref name="T2"/> value indicating the current aggregated state.
+        /// </summary>
+        public T2 CurrentState { get; private set; }
+
+        /// <summary>
+        /// The function that returns a new <typeparamref name="T2"/> aggregate from the <see cref="CurrentState"/> and the next <typeparamref name="T1"/> input.
+        /// </summary>
+        public Func<T2, T1, T2> AggregateFunc { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="AggregateStream{T1, T2}"/>.
+        /// </summary>
+        /// <param name="parent">The parent <see cref="IStream{T}"/> producing <typeparamref name="T1"/> values.</param>
+        /// <param name="aggregateFunc">The function that returns a new <typeparamref name="T2"/> aggregate from the <see cref="CurrentState"/> and the next <typeparamref name="T1"/> input.</param>
+        /// <param name="initialState">The initial <typeparamref name="T2"/> aggregate to set the <see cref="CurrentState"/> to.</param>
+        public AggregateStream(IStream<T1> parent, Func<T2, T1, T2> aggregateFunc, T2 initialState = default(T2)) : base(parent)
+        {
+            AggregateFunc = aggregateFunc;
+            CurrentState = initialState;
+        }
+
+        /// <inheritdoc/>
+        protected override T2 ProduceValue(T1 input)
+        {
+            CurrentState = AggregateFunc(CurrentState, input);
+            return CurrentState;
+        }
+    }
+}

--- a/BassClefStudio.NET.Core/Streams/ConcatStream.cs
+++ b/BassClefStudio.NET.Core/Streams/ConcatStream.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace BassClefStudio.NET.Core.Streams
+{
+    /// <summary>
+    /// An <see cref="IStream{T}"/> that concatenates and sends out the combined <see cref="StreamValue{T}"/> values of all the parent <see cref="IStream{T}"/>s.
+    /// </summary>
+    /// <typeparam name="T">The type of output values this <see cref="IStream{T}"/> produces.</typeparam>
+    public class ConcatStream<T> : IStream<T>
+    {
+        /// <inheritdoc/>
+        public bool Started { get; private set; } = false;
+
+        /// <summary>
+        /// A collection of <see cref="IStream{T}"/> parent streams, from which emitted values are passed to the <see cref="ConcatStream{T}"/>.
+        /// </summary>
+        public IStream<T>[] ParentStreams { get; }
+
+        /// <inheritdoc/>
+        public event EventHandler<StreamValue<T>> ValueEmitted;
+
+        /// <summary>
+        /// Creates a new <see cref="ConcatStream{T}"/>.
+        /// </summary>
+        /// <param name="parents">A collection of <see cref="IStream{T}"/> parent streams, from which emitted values are passed to the <see cref="ConcatStream{T}"/>.</param>
+        public ConcatStream(params IStream<T>[] parents)
+        {
+            ParentStreams = parents;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="ConcatStream{T}"/>.
+        /// </summary>
+        /// <param name="parents">A collection of <see cref="IStream{T}"/> parent streams, from which emitted values are passed to the <see cref="ConcatStream{T}"/>.</param>
+        public ConcatStream(IEnumerable<IStream<T>> parents)
+        {
+            ParentStreams = parents.ToArray();
+        }
+
+        /// <inheritdoc/>
+        public void Start()
+        {
+            if (!Started)
+            {
+                Started = true;
+                foreach (var p in ParentStreams)
+                {
+                    p.ValueEmitted += ParentValueEmitted;
+                }
+
+                foreach (var p in ParentStreams)
+                {
+                    p.Start();
+                }
+            }
+        }
+
+        private void ParentValueEmitted(object sender, StreamValue<T> e)
+        {
+            ValueEmitted?.Invoke(this, e);
+        }
+    }
+}

--- a/BassClefStudio.NET.Core/Streams/DistinctStream.cs
+++ b/BassClefStudio.NET.Core/Streams/DistinctStream.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BassClefStudio.NET.Core.Streams
+{
+    /// <summary>
+    /// An <see cref="IStream{T}"/> that filters incoming inputs from a parent <see cref="IStream{T}"/> with the previously emitted item, allowing for the filtering and comparing of distinct items.
+    /// </summary>
+    /// <typeparam name="T">The type of output values this <see cref="IStream{T}"/> produces.</typeparam>
+    public class DistinctStream<T> : IStream<T>
+    {
+        /// <inheritdoc/>
+        public bool Started { get; private set; }
+
+        /// <summary>
+        /// The previously emitted value from <see cref="ParentStream"/>.
+        /// </summary>
+        public T PreviousValue { get; private set; }
+
+        /// <summary>
+        /// A <see cref="Func{T1, T2, TResult}"/> that takes in the incoming and previous <typeparamref name="T"/> inputs and returns a <see cref="bool"/> indicating whether the incoming value should be emitted.
+        /// </summary>
+        public Func<T, T, bool> IncludeFunc { get; }
+
+        /// <summary>
+        /// The parent <see cref="IStream{T}"/> this <see cref="DistinctStream{T}"/> is based on.
+        /// </summary>
+        public IStream<T> ParentStream { get; }
+
+        /// <inheritdoc/>
+        public event EventHandler<StreamValue<T>> ValueEmitted;
+
+        /// <summary>
+        /// Creates a new <see cref="DistinctStream{T}"/>.
+        /// </summary>
+        /// <param name="parentStream">The parent <see cref="IStream{T}"/> this <see cref="DistinctStream{T}"/> is based on.</param>
+        /// <param name="includeFunc">A <see cref="Func{T1, T2, TResult}"/> that takes in the incoming and previous <typeparamref name="T"/> inputs and returns a <see cref="bool"/> indicating whether the incoming value should be emitted.</param>
+        public DistinctStream(IStream<T> parentStream, Func<T, T, bool> includeFunc)
+        {
+            ParentStream = parentStream;
+            IncludeFunc = includeFunc;
+        }
+
+        /// <inheritdoc/>
+        public void Start()
+        {
+            if(!Started)
+            {
+                Started = true;
+                PreviousValue = default(T);
+                ParentStream.ValueEmitted += ParentValueEmitted;
+                ParentStream.Start();
+            }
+        }
+
+        private void ParentValueEmitted(object sender, StreamValue<T> e)
+        {
+            if (e.DataType == StreamValueType.Completed)
+            {
+                ValueEmitted?.Invoke(this, new StreamValue<T>());
+            }
+            else if (e.DataType == StreamValueType.Error)
+            {
+                ValueEmitted?.Invoke(this, new StreamValue<T>(e.Error));
+            }
+            else if (e.DataType == StreamValueType.Result)
+            {
+                try
+                {
+                    if (IncludeFunc(e.Result, PreviousValue))
+                    {
+                        ValueEmitted?.Invoke(this, new StreamValue<T>(e.Result));
+                        PreviousValue = e.Result;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    ValueEmitted?.Invoke(this, new StreamValue<T>(ex));
+                }
+            }
+        }
+    }
+}

--- a/BassClefStudio.NET.Core/Streams/FilterStream.cs
+++ b/BassClefStudio.NET.Core/Streams/FilterStream.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BassClefStudio.NET.Core.Streams
+{
+    /// <summary>
+    /// Represents an <see cref="IStream{T}"/> which filters only certain events from a parent <see cref="IStream{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of values emitted by this <see cref="IStream{T}"/>.</typeparam>
+    public class FilterStream<T> : IStream<T>
+    {
+        /// <inheritdoc/>
+        public bool Started { get; private set; } = false;
+
+        /// <inheritdoc/>
+        public event EventHandler<StreamValue<T>> ValueEmitted;
+
+        /// <summary>
+        /// The parent <see cref="IStream{T}"/> this <see cref="FilterStream{T}"/> will filter.
+        /// </summary>
+        public IStream<T> ParentStream { get; }
+
+        /// <summary>
+        /// A function that returns a <see cref="bool"/> for each <typeparamref name="T"/> input indicating whether it should propogate onto this stream.
+        /// </summary>
+        public Func<T, bool> Filter { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="FilterStream{T}"/>.
+        /// </summary>
+        /// <param name="parent">The parent <see cref="IStream{T}"/> this <see cref="FilterStream{T}"/> will filter.</param>
+        /// <param name="filter">A function that returns a <see cref="bool"/> for each <typeparamref name="T"/> input indicating whether it should propogate onto this stream.</param>
+        public FilterStream(IStream<T> parent, Func<T, bool> filter)
+        {
+            ParentStream = parent;
+            Filter = filter;
+        }
+
+        /// <inheritdoc/>
+        public void Start()
+        {
+            if (!Started)
+            {
+                Started = true;
+                ParentStream.ValueEmitted += ParentValueEmitted;
+                ParentStream.Start();
+            }
+        }
+
+        private void ParentValueEmitted(object sender, StreamValue<T> value)
+        {
+            if (value.DataType == StreamValueType.Result)
+            {
+                try
+                {
+                    if (Filter(value.Result))
+                    {
+                        ValueEmitted?.Invoke(this, value);
+                    }
+                }
+                catch(Exception ex)
+                {
+                    ValueEmitted?.Invoke(this, new StreamValue<T>(ex));
+                }
+            }
+            else
+            {
+                ValueEmitted?.Invoke(this, value);
+            }
+        }
+    }
+}

--- a/BassClefStudio.NET.Core/Streams/IStream.cs
+++ b/BassClefStudio.NET.Core/Streams/IStream.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BassClefStudio.NET.Core.Streams
+{
+    /// <summary>
+    /// Represents a reactive stream, which outputs some series of values asynchronously over time.
+    /// </summary>
+    /// <typeparam name="T">The type of values emitted by the stream (see <see cref="ValueEmitted"/>).</typeparam>
+    public interface IStream<T>
+    {
+        /// <summary>
+        /// A <see cref="bool"/> indicating whether this <see cref="IStream{T}"/> has been started yet (see <see cref="Start"/>).
+        /// </summary>
+        bool Started { get; }
+
+        /// <summary>
+        /// An event produced by the <see cref="IStream{T}"/> every time a new value is available.
+        /// </summary>
+        event EventHandler<StreamValue<T>> ValueEmitted;
+
+        /// <summary>
+        /// If this <see cref="IStream{T}"/> contains data that is ready to be emitted, this will start the <see cref="IStream{T}"/>. Call this method after all binding and transformations to desired <see cref="IStream{T}"/>s have occurred.
+        /// </summary>
+        void Start();
+    }
+
+    /// <summary>
+    /// A struct that provides some value of type <typeparamref name="T"/> if successful, else contains information about the error that occurred.
+    /// </summary>
+    /// <typeparam name="T">The type of value this <see cref="StreamValue{T}"/> could encapsulate.</typeparam>
+    public struct StreamValue<T>
+    {
+        /// <summary>
+        /// A <see cref="StreamValueType"/> indicating what type of result this <see cref="StreamValue{T}"/> encapsulates.
+        /// </summary>
+        public StreamValueType DataType { get; private set; }
+
+        private T result;
+        /// <summary>
+        /// The <typeparamref name="T"/> result, if <see cref="DataType"/> is set to <see cref="StreamValueType.Result"/> true.
+        /// </summary>
+        public T Result
+        {
+            get
+            {
+                if(DataType == StreamValueType.Result)
+                {
+                    return result;
+                }
+                else
+                {
+                    throw new InvalidOperationException("Cannot retrieve the value of Maybe<T>.Result if DataType is not 'Result'.");
+                }
+            }
+        }
+
+        private Exception error;
+        /// <summary>
+        /// If <see cref="DataType"/> is set to <see cref="StreamValueType.Error"/>, contains the information about the <see cref="Exception"/> that was thrown.
+        /// </summary>
+        public Exception Error
+        {
+            get
+            {
+                if (DataType == StreamValueType.Error)
+                {
+                    return error;
+                }
+                else
+                {
+                    throw new InvalidOperationException("Cannot retrieve the value of Maybe<T>.Error if DataType is not 'Error'.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates a successful <see cref="StreamValue{T}"/> object that contains a <see cref="Result"/>.
+        /// </summary>
+        /// <param name="value">The <typeparamref name="T"/> result.</param>
+        public StreamValue(T value)
+        {
+            DataType = StreamValueType.Result;
+            result = value;
+            error = null;
+        }
+
+        /// <summary>
+        /// Creates a failed <see cref="StreamValue{T}"/> object that provides <see cref="Exception"/> information.
+        /// </summary>
+        /// <param name="ex">The <see cref="Exception"/> that was thrown.</param>
+        public StreamValue(Exception ex)
+        {
+            DataType = StreamValueType.Error;
+            result = default(T);
+            error = ex;
+        }
+    }
+
+    /// <summary>
+    /// For a <see cref="StreamValue{T}"/> produced by an <see cref="IStream{T}"/>, indicates the type of data being sent.
+    /// </summary>
+    public enum StreamValueType
+    {
+        /// <summary>
+        /// The default type contains no value or error, and simply indicates the <see cref="IStream{T}"/> has completed producing values.
+        /// </summary>
+        Completed = 0,
+        /// <summary>
+        /// This <see cref="StreamValue{T}"/> will contain a value as its <see cref="StreamValue{T}.Result"/>.
+        /// </summary>
+        Result = 1,
+        /// <summary>
+        /// An error occurred, and information can be found in <see cref="StreamValue{T}.Error"/>.
+        /// </summary>
+        Error = 2
+    }
+}

--- a/BassClefStudio.NET.Core/Streams/MergeStream.cs
+++ b/BassClefStudio.NET.Core/Streams/MergeStream.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace BassClefStudio.NET.Core.Streams
+{
+    /// <summary>
+    /// An <see cref="IStream{T}"/> that maps the most recent outputs from a collection of parent <see cref="IStream{T}"/>s to produce a new output value.
+    /// </summary>
+    /// <typeparam name="T1">The type of values returned by the parent <see cref="IStream{T}"/>.</typeparam>
+    /// <typeparam name="T2">The type of the transformed values this <see cref="IStream{T}"/> returns.</typeparam>
+    public class MergeStream<T1, T2> : IStream<T2>
+    {
+        /// <inheritdoc/>
+        public bool Started { get; private set; } = false;
+
+        /// <summary>
+        /// A collection of <see cref="IStream{T}"/> parent streams, from which emitted values are passed to the <see cref="ConcatStream{T}"/>.
+        /// </summary>
+        public IStream<T1>[] ParentStreams { get; }
+
+        /// <summary>
+        /// A <see cref="Func{T, TResult}"/> that produces a <typeparamref name="T2"/> result from the most recent <typeparamref name="T1"/> values produced by each of the <see cref="ParentStreams"/>.
+        /// </summary>
+        public Func<T1[], T2> TransformFunc { get; }
+
+        /// <inheritdoc/>
+        public event EventHandler<StreamValue<T2>> ValueEmitted;
+
+        /// <summary>
+        /// Creates a new <see cref="MergeStream{T1, T2}"/>.
+        /// </summary>
+        /// <param name="parents">A collection of <see cref="IStream{T}"/> parent streams, from which emitted values are passed to the <see cref="ConcatStream{T}"/>.</param>
+        /// <param name="transformFunc">A <see cref="Func{T, TResult}"/> that produces a <typeparamref name="T2"/> result from the most recent <typeparamref name="T1"/> values produced by each of the <see cref="ParentStreams"/>.</param>
+        public MergeStream(Func<T1[], T2> transformFunc, params IStream<T1>[] parents)
+        {
+            TransformFunc = transformFunc;
+            ParentStreams = parents;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="MergeStream{T1, T2}"/>.
+        /// </summary>
+        /// <param name="parents">A collection of <see cref="IStream{T}"/> parent streams, from which emitted values are passed to the <see cref="ConcatStream{T}"/>.</param>
+        /// <param name="transformFunc">A <see cref="Func{T, TResult}"/> that produces a <typeparamref name="T2"/> result from the most recent <typeparamref name="T1"/> values produced by each of the <see cref="ParentStreams"/>.</param>
+        public MergeStream(Func<T1[], T2> transformFunc, IEnumerable<IStream<T1>> parents)
+        {
+            TransformFunc = transformFunc;
+            ParentStreams = parents.ToArray();
+        }
+
+        /// <inheritdoc/>
+        public void Start()
+        {
+            CachedValues = new T1[ParentStreams.Length];
+            if (!Started)
+            {
+                Started = true;
+                for (int i = 0; i < ParentStreams.Length; i++)
+                {
+                    CachedValues[i] = default(T1);
+                    ParentStreams[i].ValueEmitted += (s, e) => ParentValueEmitted(s as IStream<T1>, e);
+                }
+
+                foreach (var parent in ParentStreams)
+                {
+                    parent.Start();
+                }
+            }
+        }
+
+        private T1[] CachedValues { get; set; }
+
+        private void ParentValueEmitted(IStream<T1> parent, StreamValue<T1> e)
+            => ParentValueEmitted(Array.IndexOf(ParentStreams, parent), e);
+        private void ParentValueEmitted(int index, StreamValue<T1> e)
+        {
+            if (e.DataType == StreamValueType.Result)
+            {
+                try
+                {
+                    CachedValues[index] = e.Result;
+                    var output = TransformFunc(CachedValues);
+                    ValueEmitted?.Invoke(this, new StreamValue<T2>(output));
+                }
+                catch(Exception ex)
+                {
+                    ValueEmitted?.Invoke(this, new StreamValue<T2>(ex));
+                }
+            }
+            else if(e.DataType == StreamValueType.Completed)
+            {
+                ValueEmitted?.Invoke(this, new StreamValue<T2>());
+                CachedValues[index] = default(T1);
+            }
+            else if(e.DataType == StreamValueType.Error)
+            {
+                ValueEmitted?.Invoke(this, new StreamValue<T2>(e.Error));
+                CachedValues[index] = default(T1);
+            }
+        }
+    }
+}

--- a/BassClefStudio.NET.Core/Streams/ParallelStreams.cs
+++ b/BassClefStudio.NET.Core/Streams/ParallelStreams.cs
@@ -1,0 +1,149 @@
+﻿using BassClefStudio.NET.Core;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BassClefStudio.NET.Core.Streams
+{
+    /// <summary>
+    /// Represents a basic <see cref="IStream{T}"/> that transforms the returned values from another parent <see cref="IStream{T}"/> asynchronously. The resulting values are added to the stream in the order they're completed.
+    /// </summary>
+    /// <typeparam name="T1">The type of values returned by the parent <see cref="IStream{T}"/>.</typeparam>
+    /// <typeparam name="T2">The type of the transformed values this <see cref="IStream{T}"/> returns.</typeparam>
+    public abstract class ParallelStream<T1, T2> : IStream<T2>
+    {
+        /// <inheritdoc/>
+        public bool Started { get; private set; } = false;
+
+        /// <inheritdoc/>
+        public event EventHandler<StreamValue<T2>> ValueEmitted;
+
+        /// <summary>
+        /// The parent <see cref="IStream{T}"/> this <see cref="ParallelStream{T1, T2}"/> is based on.
+        /// </summary>
+        public IStream<T1> ParentStream { get; }
+
+        /// <summary>
+        /// An asynchronous task that takes a <typeparamref name="T1"/> object and produces a <typeparamref name="T2"/> object.
+        /// </summary>
+        /// <param name="input">The input <typeparamref name="T1"/> from <see cref="ParentStream"/>.</param>
+        protected abstract Task<T2> ProduceValue(T1 input);
+
+        /// <summary>
+        /// Creates a new <see cref="ParallelStream{T1, T2}"/> from the 
+        /// </summary>
+        /// <param name="parent"></param>
+        public ParallelStream(IStream<T1> parent)
+        {
+            ParentStream = parent;
+        }
+
+        /// <inheritdoc/>
+        public void Start()
+        {
+            if (!Started)
+            {
+                Started = true;
+                ParentStream.ValueEmitted += ParentValueEmitted;
+                ParentStream.Start();
+            }
+        }
+
+        private void ParentValueEmitted(object sender, StreamValue<T1> e)
+        {
+            SynchronousTask inputTask = new SynchronousTask(() => ProcessInput(e));
+            inputTask.RunTask();
+        }
+
+        private async Task ProcessInput(StreamValue<T1> current)
+        {
+            if (current.DataType == StreamValueType.Completed)
+            {
+                ValueEmitted?.Invoke(this, new StreamValue<T2>());
+            }
+            else if (current.DataType == StreamValueType.Error)
+            {
+                ValueEmitted?.Invoke(this, new StreamValue<T2>(current.Error));
+            }
+            else if (current.DataType == StreamValueType.Result)
+            {
+                try
+                {
+                    var output = await ProduceValue(current.Result);
+                    ValueEmitted?.Invoke(this, new StreamValue<T2>(output));
+                }
+                catch (Exception ex)
+                {
+                    ValueEmitted?.Invoke(this, new StreamValue<T2>(ex));
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// An <see cref="IStream{T}"/>/<see cref="ParallelStream{T1, T2}"/> that maps each <typeparamref name="T1"/> value from the parent stream into a <typeparamref name="T2"/> value asynchronously and in parallel. The resulting values are added to the stream in the order they're completed.
+    /// </summary>
+    /// <typeparam name="T1">The type of values returned by the parent <see cref="IStream{T}"/>.</typeparam>
+    /// <typeparam name="T2">The type of the transformed values this <see cref="IStream{T}"/> returns.</typeparam>
+    public class ParallelMapStream<T1, T2> : ParallelStream<T1, T2>
+    {
+        /// <summary>
+        /// The asynchronous function for converting each <typeparamref name="T1"/> item to its <typeparamref name="T2"/> representation.
+        /// </summary>
+        public Func<T1, Task<T2>> ProduceFunc { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="ParallelMapStream{T1, T2}"/>.
+        /// </summary>
+        /// <param name="parent">The parent <see cref="IStream{T}"/> producing <typeparamref name="T1"/> values.</param>
+        /// <param name="mapFunc">The asynchronous function for converting each <typeparamref name="T1"/> item to its <typeparamref name="T2"/> representation.</param>
+        public ParallelMapStream(IStream<T1> parent, Func<T1, Task<T2>> mapFunc) : base(parent)
+        {
+            ProduceFunc = mapFunc;
+        }
+
+        /// <inheritdoc/>
+        protected override async Task<T2> ProduceValue(T1 input)
+        {
+            return await ProduceFunc(input);
+        }
+    }
+
+    /// <summary>
+    /// An <see cref="IStream{T}"/>/<see cref="ChildStream{T1, T2}"/> that aggregates incoming <typeparamref name="T1"/> values from the parent stream into a <typeparamref name="T2"/> <see cref="CurrentState"/>.
+    /// </summary>
+    /// <typeparam name="T1">The type of values returned by the parent <see cref="IStream{T}"/>.</typeparam>
+    /// <typeparam name="T2">The type of the transformed values this <see cref="IStream{T}"/> returns.</typeparam>
+    public class ParallelAggregateStream<T1, T2> : ParallelStream<T1, T2>
+    {
+        /// <summary>
+        /// A <typeparamref name="T2"/> value indicating the current aggregated state.
+        /// </summary>
+        public T2 CurrentState { get; private set; }
+
+        /// <summary>
+        /// The asynchronous function that returns a new <typeparamref name="T2"/> aggregate from the <see cref="CurrentState"/> and the next <typeparamref name="T1"/> input.
+        /// </summary>
+        public Func<T2, T1, Task<T2>> AggregateFunc { get; }
+
+        /// <summary>
+        /// Creates a new asynchronous <see cref="ParallelAggregateStream{T1, T2}"/>.
+        /// </summary>
+        /// <param name="parent">The parent <see cref="IStream{T}"/> producing <typeparamref name="T1"/> values.</param>
+        /// <param name="aggregateFunc">The asynchronous function that returns a new <typeparamref name="T2"/> aggregate from the <see cref="CurrentState"/> and the next <typeparamref name="T1"/> input.</param>
+        /// <param name="initialState">The initial <typeparamref name="T2"/> aggregate to set the <see cref="CurrentState"/> to.</param>
+        public ParallelAggregateStream(IStream<T1> parent, Func<T2, T1, Task<T2>> aggregateFunc, T2 initialState = default(T2)) : base(parent)
+        {
+            AggregateFunc = aggregateFunc;
+            CurrentState = initialState;
+        }
+
+        /// <inheritdoc/>
+        protected override async Task<T2> ProduceValue(T1 input)
+        {
+            CurrentState = await AggregateFunc(CurrentState, input);
+            return CurrentState;
+        }
+    }
+}

--- a/BassClefStudio.NET.Core/Streams/PropertyStream.cs
+++ b/BassClefStudio.NET.Core/Streams/PropertyStream.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BassClefStudio.NET.Core.Streams
+{
+    /// <summary>
+    /// Represents an <see cref="IStream{T}"/>/<see cref="SourceStream{T}"/> that is bound to the value of some observable <typeparamref name="T2"/> property.
+    /// </summary>
+    /// <typeparam name="T1">The type of the (usually <see cref="INotifyPropertyChanged"/>) objects that will alert the <see cref="IStream{T}"/> to incoming changes.</typeparam>
+    /// <typeparam name="T2">The type of output values this <see cref="IStream{T}"/> produces.</typeparam>
+    public class PropertyStream<T1, T2> : IStream<T2>
+    {
+        /// <inheritdoc/>
+        public bool Started { get; private set; } = false;
+
+        /// <inheritdoc/>
+        public event EventHandler<StreamValue<T2>> ValueEmitted;
+
+        /// <summary>
+        /// The parent <see cref="IStream{T}"/> that produces parent objects.
+        /// </summary>
+        public IStream<T1> ParentStream { get; }
+
+        private T1 currentParent;
+        /// <summary>
+        /// Gets the current <typeparamref name="T1"/> parent.
+        /// </summary>
+        protected T1 CurrentParent
+        {
+            get => currentParent;
+            set
+            {
+                if (currentParent != null && currentParent is INotifyPropertyChanged notifyOld)
+                {
+                    notifyOld.PropertyChanged -= ParentPropertyChanged;
+                }
+                currentParent = value;
+                if (currentParent != null)
+                {
+                    if (currentParent is INotifyPropertyChanged notifyNew)
+                    {
+                        notifyNew.PropertyChanged += ParentPropertyChanged;
+                    }
+                    CurrentValue = GetProperty(currentParent);
+                }
+            }
+        }
+
+        private T2 currentValue;
+        /// <summary>
+        /// Represents the currently stored <typeparamref name="T2"/> property value.
+        /// </summary>
+        protected T2 CurrentValue
+        {
+            get => currentValue;
+            set
+            {
+                if (!(currentValue == null && value == null) 
+                    && ((currentValue == null && value != null) 
+                    || !currentValue.Equals(value)))
+                {
+                    currentValue = value;
+                    ValueEmitted?.Invoke(this, new StreamValue<T2>(currentValue));
+                }
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="Func{T, TResult}"/> that gets the <typeparamref name="T2"/> property from the <typeparamref name="T1"/> parent.
+        /// </summary>
+        public Func<T1, T2> GetProperty { get; }
+
+        /// <summary>
+        /// For debugging purposes, can contain the name of the property this <see cref="PropertyStream{T1, T2}"/> is connected to.
+        /// </summary>
+        public string PropertyName { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="PropertyStream{T1, T2}"/>.
+        /// </summary>
+        /// <param name="parent">The parent <see cref="IStream{T}"/> that produces <see cref="INotifyPropertyChanged"/> objects.</param>
+        /// <param name="getProperty">The <see cref="Func{T, TResult}"/> that gets the <typeparamref name="T2"/> property from the <typeparamref name="T1"/> parent.</param>
+        /// <param name="propertyName">For debugging purposes, include the name of the property this <see cref="PropertyStream{T1, T2}"/> is connected to.</param>
+        public PropertyStream(IStream<T1> parent, Func<T1, T2> getProperty, string propertyName = null)
+        {
+            ParentStream = parent;
+            GetProperty = getProperty;
+            PropertyName = propertyName;
+        }
+
+        /// <inheritdoc/>
+        public void Start()
+        {
+            if (!Started)
+            {
+                Started = true;
+                ParentStream.ValueEmitted += ParentValueEmitted;
+                ParentStream.Start();
+            }
+        }
+
+        private void ParentValueEmitted(object sender, StreamValue<T1> e)
+        {
+            if (e.DataType == StreamValueType.Result)
+            {
+                CurrentParent = e.Result;
+            }
+            else if(e.DataType == StreamValueType.Error)
+            {
+                ValueEmitted?.Invoke(this, new StreamValue<T2>(e.Error));
+            }
+        }
+
+        private void ParentPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            CurrentValue = GetProperty(CurrentParent);
+        }
+    }
+}

--- a/BassClefStudio.NET.Core/Streams/RecStream.cs
+++ b/BassClefStudio.NET.Core/Streams/RecStream.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BassClefStudio.NET.Core.Streams
+{
+    /// <summary>
+    /// An <see cref="IStream{T}"/> which attaches to a parent <see cref="IStream{T}"/> only at the point the stream is started (see <see cref="IStream{T}.Start"/>).
+    /// </summary>
+    /// <typeparam name="T">The type of output values this <see cref="IStream{T}"/> produces.</typeparam>
+    public class RecStream<T> : IStream<T>
+    {
+        /// <inheritdoc/>
+        public bool Started { get; private set; }
+
+        /// <summary>
+        /// A <see cref="Func{TResult}"/> that will, when evaluated, return the parent <see cref="IStream{T}"/>.
+        /// </summary>
+        public Func<IStream<T>> GetStream { get; }
+
+        /// <summary>
+        /// The evaluated <see cref="IStream{T}"/> parent stream.
+        /// </summary>
+        private IStream<T> ParentStream { get; set; }
+
+        /// <inheritdoc/>
+        public event EventHandler<StreamValue<T>> ValueEmitted;
+
+        /// <summary>
+        /// Creates a new <see cref="RecStream{T}"/>.
+        /// </summary>
+        /// <param name="getStream">A <see cref="Func{TResult}"/> that will, when evaluated, return the parent <see cref="IStream{T}"/>.</param>
+        public RecStream(Func<IStream<T>> getStream)
+        {
+            GetStream = getStream;
+        }
+
+        /// <inheritdoc/>
+        public void Start()
+        {
+            if(!Started)
+            {
+                Started = true;
+                ParentStream = GetStream();
+                ParentStream.ValueEmitted += ParentValueEmitted;
+                ParentStream.Start();
+            }
+        }
+
+        private void ParentValueEmitted(object sender, StreamValue<T> e)
+        {
+            ValueEmitted?.Invoke(this, e);
+        }
+    }
+}

--- a/BassClefStudio.NET.Core/Streams/SourceStream.cs
+++ b/BassClefStudio.NET.Core/Streams/SourceStream.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BassClefStudio.NET.Core.Streams
+{
+    /// <summary>
+    /// Represents the most basic implementation of <see cref="IStream{T}"/> that produces content.
+    /// </summary>
+    /// <typeparam name="T">The type of output values this <see cref="IStream{T}"/> produces.</typeparam>
+    public class SourceStream<T> : IStream<T>
+    {
+        /// <inheritdoc/>
+        public bool Started { get; private set; } = false;
+
+        /// <inheritdoc/>
+        public event EventHandler<StreamValue<T>> ValueEmitted;
+
+        /// <summary>
+        /// Creates an empty <see cref="SourceStream{T}"/>.
+        /// </summary>
+        public SourceStream()
+        {
+            StartInputs = Array.Empty<StreamValue<T>>();
+        }
+
+        /// <summary>
+        /// A collection of <see cref="StreamValue{T}"/> inputs that will be sent onto the <see cref="SourceStream{T}"/> when <see cref="IStream{T}.Start"/> is called.
+        /// </summary>
+        public IEnumerable<StreamValue<T>> StartInputs { get; protected set; }
+
+        /// <summary>
+        /// Creates a <see cref="SourceStream{T}"/> with a collection of <see cref="StreamValue{T}"/> inputs.
+        /// </summary>
+        /// <param name="inputs">A collection of <see cref="StreamValue{T}"/> inputs that will be sent onto the <see cref="SourceStream{T}"/> when <see cref="IStream{T}.Start"/> is called.</param>
+        public SourceStream(IEnumerable<StreamValue<T>> inputs)
+        {
+            StartInputs = inputs;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="SourceStream{T}"/> with a collection of <see cref="StreamValue{T}"/> inputs.
+        /// </summary>
+        /// <param name="inputs">A collection of <see cref="StreamValue{T}"/> inputs that will be sent onto the <see cref="SourceStream{T}"/> when <see cref="IStream{T}.Start"/> is called.</param>
+        public SourceStream(params StreamValue<T>[] inputs)
+        {
+            StartInputs = inputs;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="SourceStream{T}"/> with a collection of <typeparamref name="T"/> inputs.
+        /// </summary>
+        /// <param name="inputs">A collection of <typeparamref name="T"/> inputs that will be sent onto the <see cref="SourceStream{T}"/> when <see cref="IStream{T}.Start"/> is called.</param>
+        public SourceStream(IEnumerable<T> inputs)
+        {
+            StartInputs = inputs.Select(t => new StreamValue<T>(t));
+        }
+
+        /// <summary>
+        /// Creates a <see cref="SourceStream{T}"/> with a collection of <typeparamref name="T"/> inputs.
+        /// </summary>
+        /// <param name="inputs">A collection of <typeparamref name="T"/> inputs that will be sent onto the <see cref="SourceStream{T}"/> when <see cref="IStream{T}.Start"/> is called.</param>
+        public SourceStream(params T[] inputs)
+        {
+            StartInputs = inputs.Select(t => new StreamValue<T>(t));
+        }
+
+        /// <summary>
+        /// Creates a <see cref="SourceStream{T}"/> that returns consecutive <see cref="int"/> values.
+        /// </summary>
+        /// <param name="start">The starting <see cref="int"/> to begin with.</param>
+        /// <param name="length">The number of items to emit.</param>
+        /// <returns>A new <see cref="SourceStream{T}"/> that outputs <see cref="int"/> values.</returns>
+        public static SourceStream<int> CountStream(int start, int length)
+        {
+            return new SourceStream<int>(Enumerable.Range(start, length));
+        }
+
+        /// <summary>
+        /// Creates a <see cref="SourceStream{T}"/> that returns some <typeparamref name="T"/> value multiple times.
+        /// </summary>
+        /// <param name="value">The <typeparamref name="T"/> value to emit.</param>
+        /// <param name="length">The number of items to emit.</param>
+        /// <returns>A new <see cref="SourceStream{T}"/> that outputs <paramref name="value"/> <paramref name="length"/> times.</returns>
+        public static SourceStream<T> Repeat(T value, int length)
+        {
+            return new SourceStream<T>(Enumerable.Repeat(value, length));
+        }
+
+        /// <inheritdoc/>
+        public void Start()
+        {
+            if (!Started)
+            {
+                Started = true;
+                EmitValues(StartInputs);
+            }
+        }
+
+        /// <summary>
+        /// Emits a value to the stream.
+        /// </summary>
+        /// <param name="input">The pertinent <typeparamref name="T"/> value.</param>
+        public void EmitValue(StreamValue<T> input)
+        {
+            ValueEmitted?.Invoke(this, input);
+        }
+
+        /// <summary>
+        /// Emits a collection of values to the stream.
+        /// </summary>
+        /// <param name="inputs">The pertinent <typeparamref name="T"/> values.</param>
+        public void EmitValues(IEnumerable<StreamValue<T>> inputs)
+        {
+            foreach (var item in inputs)
+            {
+                EmitValue(item);
+            }
+        }
+
+        /// <summary>
+        /// Emits a value to the stream.
+        /// </summary>
+        /// <param name="input">The pertinent <typeparamref name="T"/> value.</param>
+        public void EmitValue(T input)
+        {
+            ValueEmitted?.Invoke(this, new StreamValue<T>(input));
+        }
+
+        /// <summary>
+        /// Emits a collection of values to the stream.
+        /// </summary>
+        /// <param name="inputs">The pertinent <typeparamref name="T"/> values.</param>
+        public void EmitValues(IEnumerable<T> inputs)
+        {
+            foreach (var item in inputs)
+            {
+                EmitValue(item);
+            }
+        }
+
+        /// <summary>
+        /// Throws an exception onto the stream.
+        /// </summary>
+        /// <param name="ex">The <see cref="Exception"/> describing the error.</param>
+        public void ThrowError(Exception ex)
+        {
+            ValueEmitted?.Invoke(this, new StreamValue<T>(ex));
+        }
+
+        /// <summary>
+        /// Completes (see <see cref="StreamValueType.Completed"/>) the stream.
+        /// </summary>
+        public void Complete()
+        {
+            ValueEmitted?.Invoke(this, new StreamValue<T>());
+        }
+    }
+}

--- a/BassClefStudio.NET.Core/Streams/StreamException.cs
+++ b/BassClefStudio.NET.Core/Streams/StreamException.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BassClefStudio.NET.Core.Streams
+{
+    /// <summary>
+    /// An <see cref="Exception"/> thrown whenever an <see cref="IStream{T}"/> operation or extension method fails.
+    /// </summary>
+    [Serializable]
+    public class StreamException : Exception
+    {
+        /// <inheritdoc/>
+        public StreamException() { }
+        /// <inheritdoc/>
+        public StreamException(string message) : base(message) { }
+        /// <inheritdoc/>
+        public StreamException(string message, Exception inner) : base(message, inner) { }
+        /// <inheritdoc/>
+        protected StreamException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
+}

--- a/BassClefStudio.NET.Core/Streams/StreamExtensions.cs
+++ b/BassClefStudio.NET.Core/Streams/StreamExtensions.cs
@@ -1,0 +1,506 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BassClefStudio.NET.Core.Streams
+{
+    /// <summary>
+    /// Provides a series of extension methods for dealing with <see cref="IStream{T}"/>s of all types.
+    /// </summary>
+    public static class StreamExtensions
+    {
+        #region Cast
+
+        /// <summary>
+        /// Creates an <see cref="IStream{T}"/> that returns the values of the given <see cref="IStream{T}"/> as type <typeparamref name="T2"/>.
+        /// </summary>
+        /// <typeparam name="T1">The type of values returned by the parent <see cref="IStream{T}"/>.</typeparam>
+        /// <typeparam name="T2">The type of the cast values this <see cref="IStream{T}"/> returns.</typeparam>
+        /// <param name="stream">The parent <see cref="IStream{T}"/> producing <typeparamref name="T1"/> values.</param>
+        /// <returns>An <see cref="IStream{T}"/> that returns cast <typeparamref name="T2"/> values.</returns>
+        public static IStream<T2> As<T1, T2>(this IStream<T1> stream) where T1 : T2
+        {
+            return new MapStream<T1, T2>(stream, t1 => (T2)t1);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="IStream{T}"/> that attempts to cast the values of the given <see cref="IStream{T}"/> as type <typeparamref name="T2"/>.
+        /// </summary>
+        /// <typeparam name="T1">The type of values returned by the parent <see cref="IStream{T}"/>.</typeparam>
+        /// <typeparam name="T2">The type of the cast values this <see cref="IStream{T}"/> returns.</typeparam>
+        /// <param name="stream">The parent <see cref="IStream{T}"/> producing <typeparamref name="T1"/> values.</param>
+        /// <returns>An <see cref="IStream{T}"/> that returns cast <typeparamref name="T2"/> values.</returns>
+        public static IStream<T2> Cast<T1, T2>(this IStream<T1> stream)
+        {
+            return new MapStream<T1, T2>(
+                stream,
+                t1 => t1 is T2 t2
+                    ? t2
+                    : throw new StreamException($"Invalid casting in MapStream: {t1?.GetType()?.Name} to {typeof(T2).Name}."));
+        }
+
+        #endregion
+        #region Select
+
+        /// <summary>
+        /// Creates an <see cref="IStream{T}"/> that maps the values of the given <see cref="IStream{T}"/> as <typeparamref name="T2"/> values.
+        /// </summary>
+        /// <typeparam name="T1">The type of values returned by the parent <see cref="IStream{T}"/>.</typeparam>
+        /// <typeparam name="T2">The type of the values this <see cref="IStream{T}"/> returns.</typeparam>
+        /// <param name="stream">The parent <see cref="IStream{T}"/> producing <typeparamref name="T1"/> values.</param>
+        /// <param name="mapFunc">The function for converting each <typeparamref name="T1"/> item to its <typeparamref name="T2"/> representation.</param>
+        /// <returns>An <see cref="IStream{T}"/> that returns resulting <typeparamref name="T2"/> values.</returns>
+        public static IStream<T2> Select<T1, T2>(this IStream<T1> stream, Func<T1, T2> mapFunc)
+        {
+            return new MapStream<T1, T2>(stream, mapFunc);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="IStream{T}"/> that maps the values of the given <see cref="IStream{T}"/> asynchronously as <typeparamref name="T2"/> values.
+        /// </summary>
+        /// <typeparam name="T1">The type of values returned by the parent <see cref="IStream{T}"/>.</typeparam>
+        /// <typeparam name="T2">The type of the values this <see cref="IStream{T}"/> returns.</typeparam>
+        /// <param name="stream">The parent <see cref="IStream{T}"/> producing <typeparamref name="T1"/> values.</param>
+        /// <param name="mapFunc">The asynchronous function for converting each <typeparamref name="T1"/> item to its <typeparamref name="T2"/> representation.</param>
+        /// <returns>An <see cref="IStream{T}"/> that returns resulting <typeparamref name="T2"/> values as they're converted.</returns>        
+        public static IStream<T2> Select<T1, T2>(this IStream<T1> stream, Func<T1, Task<T2>> mapFunc)
+        {
+            return new ParallelMapStream<T1, T2>(stream, mapFunc);
+        }
+
+        #endregion
+        #region Where
+
+        /// <summary>
+        /// Creates an <see cref="IStream{T}"/> that filters the values returned by the given <see cref="IStream{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of values returned by the parent <see cref="IStream{T}"/>.</typeparam>
+        /// <param name="stream">The parent <see cref="IStream{T}"/> producing <typeparamref name="T"/> values.</param>
+        /// <param name="filter">A function that returns a <see cref="bool"/> for each <typeparamref name="T"/> input indicating whether it should propogate onto this stream.</param>
+        /// <returns>An <see cref="IStream{T}"/> that returns only the filtered <typeparamref name="T"/> values.</returns>
+        public static IStream<T> Where<T>(this IStream<T> stream, Func<T, bool> filter)
+        {
+            return new FilterStream<T>(stream, filter);
+        }
+
+        #endregion
+        #region Aggregate
+
+        /// <summary>
+        /// Creates an <see cref="IStream{T}"/> that aggregates the values of the given <see cref="IStream{T}"/> into a <typeparamref name="T2"/> returned state.
+        /// </summary>
+        /// <typeparam name="T1">The type of values returned by the parent <see cref="IStream{T}"/>.</typeparam>
+        /// <typeparam name="T2">The type of the values this <see cref="IStream{T}"/> returns.</typeparam>
+        /// <param name="stream">The parent <see cref="IStream{T}"/> producing <typeparamref name="T1"/> values.</param>
+        /// <param name="aggregateFunc">The function that returns a new <typeparamref name="T2"/> aggregate from the current <typeparamref name="T2"/> state and the next <typeparamref name="T1"/> input.</param>
+        /// <param name="initialState">The initial <typeparamref name="T2"/> state.</param>
+        /// <returns>An <see cref="IStream{T}"/> that returns resulting <typeparamref name="T2"/> values.</returns>
+        public static IStream<T2> Aggregate<T1, T2>(this IStream<T1> stream, Func<T2, T1, T2> aggregateFunc, T2 initialState = default(T2))
+        {
+            return new AggregateStream<T1, T2>(stream, aggregateFunc, initialState);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="IStream{T}"/> that aggregates the values of the given <see cref="IStream{T}"/> asynchronously into a <typeparamref name="T2"/> returned state.
+        /// </summary>
+        /// <typeparam name="T1">The type of values returned by the parent <see cref="IStream{T}"/>.</typeparam>
+        /// <typeparam name="T2">The type of the values this <see cref="IStream{T}"/> returns.</typeparam>
+        /// <param name="stream">The parent <see cref="IStream{T}"/> producing <typeparamref name="T1"/> values.</param>
+        /// <param name="aggregateFunc">The asynchronous function that returns a new <typeparamref name="T2"/> aggregate from the current <typeparamref name="T2"/> state and the next <typeparamref name="T1"/> input.</param>
+        /// <param name="initialState">The initial <typeparamref name="T2"/> state.</param>
+        /// <returns>An <see cref="IStream{T}"/> that returns resulting <typeparamref name="T2"/> values as they're produced.</returns>
+        public static IStream<T2> Aggregate<T1, T2>(this IStream<T1> stream, Func<T2, T1, Task<T2>> aggregateFunc, T2 initialState = default(T2))
+        {
+            return new ParallelAggregateStream<T1, T2>(stream, aggregateFunc, initialState);
+        }
+
+        #endregion
+        #region Join
+
+        /// <summary>
+        /// Joins an <see cref="IStream{T}"/> to an existing <see cref="IStream{T}"/> to create a concatenated <see cref="IStream{T}"/> with all of the output values of both existing streams.
+        /// </summary>
+        /// <typeparam name="T">The type of the values this <see cref="IStream{T}"/> returns.</typeparam>
+        /// <param name="stream">The first <see cref="IStream{T}"/>.</param>
+        /// <param name="other">The <see cref="IStream{T}"/> to concatenate with <paramref name="stream"/>.</param>
+        /// <returns>An <see cref="IStream{T}"/> that emits all values recieved from both parent <see cref="IStream{T}"/>s.</returns>
+        public static IStream<T> Join<T>(this IStream<T> stream, IStream<T> other)
+        {
+            return new ConcatStream<T>(stream, other);
+        }
+
+        /// <summary>
+        /// Joins a collection of <see cref="IStream{T}"/>s to create a concatenated <see cref="IStream{T}"/> with all of the output values of both existing streams.
+        /// </summary>
+        /// <typeparam name="T">The type of the values this <see cref="IStream{T}"/> returns.</typeparam>
+        /// <param name="streams">The parent <see cref="IStream{T}"/>s producing <typeparamref name="T"/> values.</param>
+        /// <returns>An <see cref="IStream{T}"/> that emits all values recieved from all parent <see cref="IStream{T}"/>s.</returns>
+        public static IStream<T> Join<T>(this IEnumerable<IStream<T>> streams)
+        {
+            return new ConcatStream<T>(streams);
+        }
+
+        /// <summary>
+        /// Merges a collection of <see cref="IStream{T}"/>s to produce output <typeparamref name="T2"/> values from their combined <typeparamref name="T1"/> emitted values.
+        /// </summary>
+        /// <param name="streams">The parent <see cref="IStream{T}"/>s producing <typeparamref name="T1"/> values.</param>
+        /// <param name="transformFunc">A <see cref="Func{T, TResult}"/> that produces a <typeparamref name="T2"/> result from the most recent <typeparamref name="T1"/> values produced by each of the parent <see cref="IStream{T}"/>s.</param>
+        /// <typeparam name="T1">The type of values returned by the parent <see cref="IStream{T}"/>s.</typeparam>
+        /// <typeparam name="T2">The type of the values this <see cref="IStream{T}"/> returns.</typeparam>
+        /// <returns>An <see cref="IStream{T}"/> that emits <typeparamref name="T2"/> transformed values every time a parent <see cref="IStream{T}"/> emits a new <typeparamref name="T1"/> input.</returns>
+        public static IStream<T2> Join<T1, T2>(this IEnumerable<IStream<T1>> streams, Func<T1[], T2> transformFunc)
+        {
+            return new MergeStream<T1, T2>(transformFunc, streams);
+        }
+
+        /// <summary>
+        /// Merges this <see cref="IStream{T}"/> with another <see cref="IStream{T}"/> to produce output <typeparamref name="T2"/> values from their combined <typeparamref name="T1"/> emitted values.
+        /// </summary>
+        /// <param name="stream">The first <see cref="IStream{T}"/>.</param>
+        /// <param name="other">The second/other <see cref="IStream{T}"/> which will merge with this <paramref name="stream"/>.</param>
+        /// <param name="transformFunc">A <see cref="Func{T, TResult}"/> that produces a <typeparamref name="T2"/> result from the most recent <typeparamref name="T1"/> values produced by the two parent <see cref="IStream{T}"/>s.</param>
+        /// <typeparam name="T1">The type of values returned by the parent <see cref="IStream{T}"/>s.</typeparam>
+        /// <typeparam name="T2">The type of the values this <see cref="IStream{T}"/> returns.</typeparam>
+        /// <returns>An <see cref="IStream{T}"/> that emits <typeparamref name="T2"/> transformed values every time a parent <see cref="IStream{T}"/> emits a new <typeparamref name="T1"/> input.</returns>
+        public static IStream<T2> Join<T1, T2>(this IStream<T1> stream, IStream<T1> other, Func<T1, T1, T2> transformFunc)
+        {
+            return new MergeStream<T1, T2>(ts => transformFunc(ts[0], ts[1]), stream, other);
+        }
+
+        #endregion
+        #region Distinct
+
+        /// <summary>
+        /// Creates an <see cref="IStream{T}"/> that only returns all consecutive unique output values.
+        /// </summary>
+        /// <typeparam name="T">The type of the values this <see cref="IStream{T}"/> returns.</typeparam>
+        /// <param name="stream">The parent <see cref="IStream{T}"/>.</param>
+        /// <returns>An <see cref="IStream{T}"/> returning (locally) unique <typeparamref name="T"/> outputs.</returns>
+        public static IStream<T> Unique<T>(this IStream<T> stream)
+        {
+            return new DistinctStream<T>(stream, (t1, t2) => !Equals(t1, t2));
+        }
+
+        /// <summary>
+        /// Creates an <see cref="IStream{T}"/> that only returns all consecutive unique output values, as determined by the <see cref="IEquatable{T}.Equals(T)"/> method.
+        /// </summary>
+        /// <typeparam name="T">The type of the values this <see cref="IStream{T}"/> returns.</typeparam>
+        /// <param name="stream">The parent <see cref="IStream{T}"/>.</param>
+        /// <returns>An <see cref="IStream{T}"/> returning (locally) unique <typeparamref name="T"/> outputs.</returns>
+        public static IStream<T> UniqueEq<T>(this IStream<T> stream) where T : IEquatable<T>
+        {
+           return new DistinctStream<T>(
+                stream, 
+                (t1, t2) => (!(t1 == null && t2 == null)
+                    && ((t1 == null && t2 != null)
+                    || !t1.Equals(t2))));
+        }
+
+        /// <summary>
+        /// Creates an <see cref="IStream{T}"/> that filters consecutive output values through a given function.
+        /// </summary>
+        /// <typeparam name="T">The type of the values this <see cref="IStream{T}"/> returns.</typeparam>
+        /// <param name="stream">The parent <see cref="IStream{T}"/>.</param>
+        /// <param name="includeFunc">A <see cref="Func{T1, T2, TResult}"/> that takes in the incoming and previous <typeparamref name="T"/> inputs and returns a <see cref="bool"/> indicating whether the incoming value should be emitted.</param>
+        /// <returns>An <see cref="IStream{T}"/> returning (locally) included <typeparamref name="T"/> outputs as per <paramref name="includeFunc"/>.</returns>
+        public static IStream<T> Distinct<T>(this IStream<T> stream, Func<T, T, bool> includeFunc)
+        {
+            return new DistinctStream<T>(stream, includeFunc);
+        }
+
+        #endregion
+        #region Sum
+
+        /// <summary>
+        /// Creates an <see cref="IStream{T}"/> that returns the sum of all the values returned by the given <see cref="IStream{T}"/> up to that point.
+        /// </summary>
+        /// <param name="stream">The parent <see cref="IStream{T}"/> producing <see cref="int"/> values.</param>
+        /// <returns>An <see cref="IStream{T}"/> that returns resulting sums.</returns>
+        public static IStream<int> Sum(this IStream<int> stream)
+        {
+            return new AggregateStream<int, int>(stream, (sum, val) => sum + val, 0);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="IStream{T}"/> that returns the sum of all the values returned by the given <see cref="IStream{T}"/> up to that point.
+        /// </summary>
+        /// <param name="stream">The parent <see cref="IStream{T}"/> producing <see cref="double"/> values.</param>
+        /// <returns>An <see cref="IStream{T}"/> that returns resulting sums.</returns>
+        public static IStream<double> Sum(this IStream<double> stream)
+        {
+            return new AggregateStream<double, double>(stream, (sum, val) => sum + val, 0);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="IStream{T}"/> that returns the sum of all the values returned by the given <see cref="IStream{T}"/> up to that point.
+        /// </summary>
+        /// <param name="stream">The parent <see cref="IStream{T}"/> producing <see cref="int"/> values.</param>
+        /// <returns>An <see cref="IStream{T}"/> that returns resulting sums.</returns>
+        public static IStream<float> Sum(this IStream<float> stream)
+        {
+            return new AggregateStream<float, float>(stream, (sum, val) => sum + val, 0);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="IStream{T}"/> that returns the count of values returned by the <see cref="IStream{T}"/> parent.
+        /// </summary>
+        /// <param name="stream">The parent <see cref="IStream{T}"/>.</param>
+        /// <returns>An <see cref="IStream{T}"/> that returns the resulting count.</returns>
+        public static IStream<int> Count<T>(this IStream<T> stream)
+        {
+            return new AggregateStream<T, int>(stream, (i, t) => i + 1, 0);
+        }
+
+        #endregion
+        #region Bind
+
+        /// <summary>
+        /// Binds the incoming <typeparamref name="T"/> results from an <see cref="IStream{T}"/> to a given <see cref="Action{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of values emitted by this <see cref="IStream{T}"/>.</typeparam>
+        /// <typeparam name="TStream">The type of <see cref="IStream{T}"/> being bound to.</typeparam>
+        /// <param name="stream">The <see cref="IStream{T}"/> stream to bind to.</param>
+        /// <param name="action">An action that takes in an input <typeparamref name="T"/> value and will be executed every time the <paramref name="stream"/> emits a value of <see cref="StreamValueType.Result"/>.</param>
+        /// <returns>The input <see cref="IStream{T}"/> <paramref name="stream"/>.</returns>
+        public static TStream BindResult<T, TStream>(this TStream stream, Action<T> action) where TStream : IStream<T>
+        {
+            stream.ValueEmitted += (s, e) =>
+            {
+                if(e.DataType == StreamValueType.Result)
+                {
+                    action(e.Result);
+                }
+            };
+            return stream;
+        }
+
+        /// <summary>
+        /// Binds any incoming <see cref="Exception"/>s from an <see cref="IStream{T}"/> to a given <see cref="Action{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of values emitted by this <see cref="IStream{T}"/>.</typeparam>
+        /// <typeparam name="TStream">The type of <see cref="IStream{T}"/> being bound to.</typeparam>
+        /// <param name="stream">The <see cref="IStream{T}"/> stream to bind to.</param>
+        /// <param name="action">An action that takes in an input <see cref="Exception"/> and will be executed every time the <paramref name="stream"/> emits a value of <see cref="StreamValueType.Error"/>.</param>
+        /// <returns>The input <see cref="IStream{T}"/> <paramref name="stream"/>.</returns>
+        public static TStream BindError<T, TStream>(this TStream stream, Action<Exception> action) where TStream : IStream<T>
+        {
+            stream.ValueEmitted += (s, e) =>
+            {
+                if (e.DataType == StreamValueType.Error)
+                {
+                    action(e.Error);
+                }
+            };
+            return stream;
+        }
+
+        /// <summary>
+        /// Binds the completion of an <see cref="IStream{T}"/> to a given <see cref="Action"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of values emitted by this <see cref="IStream{T}"/>.</typeparam>
+        /// <typeparam name="TStream">The type of <see cref="IStream{T}"/> being bound to.</typeparam>
+        /// <param name="stream">The <see cref="IStream{T}"/> stream to bind to.</param>
+        /// <param name="action">An action that will be executed every time the <paramref name="stream"/> emits a value of <see cref="StreamValueType.Completed"/>.</param>
+        /// <returns>The input <see cref="IStream{T}"/> <paramref name="stream"/>.</returns>
+        public static TStream BindComplete<T, TStream>(this TStream stream, Action action) where TStream : IStream<T>
+        {
+            stream.ValueEmitted += (s, e) =>
+            {
+                if (e.DataType == StreamValueType.Completed)
+                {
+                    action();
+                }
+            };
+            return stream;
+        }
+
+        /// <summary>
+        /// Binds the incoming <typeparamref name="T"/> results from an <see cref="IStream{T}"/> to a given <see cref="Action{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of values emitted by this <see cref="IStream{T}"/>.</typeparam>
+        /// <param name="stream">The <see cref="IStream{T}"/> stream to bind to.</param>
+        /// <param name="action">An action that takes in an input <typeparamref name="T"/> value and will be executed every time the <paramref name="stream"/> emits a value of <see cref="StreamValueType.Result"/>.</param>
+        /// <returns>The input <see cref="IStream{T}"/> <paramref name="stream"/>.</returns>
+        public static IStream<T> BindResult<T>(this IStream<T> stream, Action<T> action)
+        {
+            stream.ValueEmitted += (s, e) =>
+            {
+                if (e.DataType == StreamValueType.Result)
+                {
+                    action(e.Result);
+                }
+            };
+            return stream;
+        }
+
+        /// <summary>
+        /// Binds any incoming <see cref="Exception"/>s from an <see cref="IStream{T}"/> to a given <see cref="Action{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of values emitted by this <see cref="IStream{T}"/>.</typeparam>
+        /// <param name="stream">The <see cref="IStream{T}"/> stream to bind to.</param>
+        /// <param name="action">An action that takes in an input <see cref="Exception"/> and will be executed every time the <paramref name="stream"/> emits a value of <see cref="StreamValueType.Error"/>.</param>
+        /// <returns>The input <see cref="IStream{T}"/> <paramref name="stream"/>.</returns>
+        public static IStream<T> BindError<T>(this IStream<T> stream, Action<Exception> action)
+        {
+            stream.ValueEmitted += (s, e) =>
+            {
+                if (e.DataType == StreamValueType.Error)
+                {
+                    action(e.Error);
+                }
+            };
+            return stream;
+        }
+
+        /// <summary>
+        /// Binds the completion of an <see cref="IStream{T}"/> to a given <see cref="Action"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of values emitted by this <see cref="IStream{T}"/>.</typeparam>
+        /// <param name="stream">The <see cref="IStream{T}"/> stream to bind to.</param>
+        /// <param name="action">An action that will be executed every time the <paramref name="stream"/> emits a value of <see cref="StreamValueType.Completed"/>.</param>
+        /// <returns>The input <see cref="IStream{T}"/> <paramref name="stream"/>.</returns>
+        public static IStream<T> BindComplete<T>(this IStream<T> stream, Action action)
+        {
+            stream.ValueEmitted += (s, e) =>
+            {
+                if (e.DataType == StreamValueType.Completed)
+                {
+                    action();
+                }
+            };
+            return stream;
+        }
+
+        #endregion
+        #region Properties
+
+        /// <summary>
+        /// Returns an <see cref="IStream{T}"/> that emits the change-notified values of the given <typeparamref name="T2"/> property on this <typeparamref name="T1"/> object.
+        /// </summary>
+        /// <typeparam name="T1">The type of the (usually <see cref="INotifyPropertyChanged"/>) objects that will alert the <see cref="IStream{T}"/> to incoming changes.</typeparam>
+        /// <typeparam name="T2">The type of output values this <see cref="IStream{T}"/> produces.</typeparam>
+        /// <param name="parent">The parent <see cref="IStream{T}"/> that produces parent objects.</param>
+        /// <param name="getProperty">The <see cref="Func{T, TResult}"/> that gets the <typeparamref name="T2"/> property from the <typeparamref name="T1"/> parent.</param>
+        /// <param name="propertyName">For debugging purposes, include the name of the property this <see cref="IStream{T}"/> is retrieving.</param>
+        /// <returns>An <see cref="IStream{T}"/> that returns the <typeparamref name="T2"/> property values.</returns>
+        public static IStream<T2> Property<T1, T2>(this IStream<T1> parent, Func<T1, T2> getProperty, string propertyName = null)
+        {
+            return new PropertyStream<T1, T2>(parent, getProperty, propertyName);
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IStream{T}"/> that emits the change-notified values of the given <typeparamref name="T2"/> property on this <typeparamref name="T1"/> object.
+        /// </summary>
+        /// <typeparam name="T1">The type of the (usually <see cref="INotifyPropertyChanged"/>) objects that will alert the <see cref="IStream{T}"/> to incoming changes.</typeparam>
+        /// <typeparam name="T2">The type of output values this <see cref="IStream{T}"/> produces.</typeparam>
+        /// <param name="parent">The parent <see cref="IStream{T}"/> that produces parent objects.</param>
+        /// <param name="propertyPath">The <see cref="string"/>, dot-delimited path to the desired property.</param>
+        /// <returns>An <see cref="IStream{T}"/> that returns <typeparamref name="T2"/> property values through reflection.</returns>
+        public static IStream<T2> Property<T1, T2>(this IStream<T1> parent, string propertyPath)
+        {
+            var pathParts = propertyPath.Split(new string[] { "." }, StringSplitOptions.None);
+            Type currentType = typeof(T1);
+            IStream<object> currentBinding = parent.Cast<T1, object>();
+            foreach (var part in pathParts)
+            {
+                var property = currentType.GetProperty(part);
+                if (property == null)
+                {
+                    throw new StreamException($"Failed to find property with name {part} on type {currentType.Name}.");
+                }
+
+                currentBinding = currentBinding.Property(
+                         o => property.GetValue(o),
+                         property.Name);
+
+                currentType = property.PropertyType;
+            }
+            return currentBinding.Cast<object, T2>();
+        }
+
+        #endregion
+        #region Source
+
+        /// <summary>
+        /// Returns a deferred <see cref="IStream{T}"/> that will emit the given value when <see cref="IStream{T}.Start"/> is called.
+        /// </summary>
+        /// <typeparam name="T">The type of value emitted by this <see cref="IStream{T}"/>.</typeparam>
+        /// <param name="value">The singular <typeparamref name="T"/> value to emit.</param>
+        /// <returns>An <see cref="IStream{T}"/> that will emit <paramref name="value"/> when <see cref="IStream{T}.Start"/> is called.</returns>
+        public static IStream<T> AsStream<T>(this T value)
+        {
+            return new SourceStream<T>(value);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="IStream{T}"/> that will lazily evaluate the provided <see cref="Func{TResult}"/> to find the parent <see cref="IStream{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of output values this <see cref="IStream{T}"/> produces.</typeparam>
+        /// <param name="getStream">A <see cref="Func{TResult}"/> that will, when evaluated, return the parent <see cref="IStream{T}"/>.</param>
+        /// <returns>An <see cref="IStream{T}"/> that will resolve when <see cref="IStream{T}.Start"/> is called.</returns>
+        public static IStream<T> Rec<T>(this Func<IStream<T>> getStream)
+        {
+            return new RecStream<T>(getStream);
+        }
+
+        #endregion
+        #region Time
+
+        /// <summary>
+        /// Returns an <see cref="IStream{T}"/> that buffers inputs into blocks spanning a time given by a specified <see cref="TimeSpan"/>. The emitted <typeparamref name="T2"/> values are generated by the given buffer function.
+        /// </summary>
+        /// <typeparam name="T1">The type of values returned by the parent <see cref="IStream{T}"/>.</typeparam>
+        /// <typeparam name="T2">The type of the transformed values this <see cref="IStream{T}"/> returns.</typeparam>
+        /// <param name="stream">The parent <see cref="IStream{T}"/> producing <typeparamref name="T1"/> values.</param>
+        /// <param name="timeSpan">A <see cref="TimeSpan"/> indicating the amount of time to buffer potential inputs.</param>
+        /// <param name="bufferFunc">The <see cref="Func{T, TResult}"/> that gets the <typeparamref name="T2"/> value from a buffered list of <typeparamref name="T1"/> items.</param>
+        /// <returns>An <see cref="IStream{T}"/> that returns a <typeparamref name="T2"/> output after a <paramref name="timeSpan"/> of time for each group of <typeparamref name="T1"/> inputs recieved during that time.</returns>
+        public static IStream<T2> Buffer<T1, T2>(this IStream<T1> stream, TimeSpan timeSpan, Func<IEnumerable<T1>, T2> bufferFunc)
+        {
+            return new BufferStream<T1, T2>(stream, timeSpan, bufferFunc);
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IStream{T}"/> that buffers inputs over a time given by a specified <see cref="TimeSpan"/>. The emitted <typeparamref name="T"/> values are the first from each buffered group.
+        /// </summary>
+        /// <typeparam name="T">The type of values returned by the parent <see cref="IStream{T}"/>.</typeparam>
+        /// <param name="stream">The parent <see cref="IStream{T}"/> producing <typeparamref name="T"/> values.</param>
+        /// <param name="timeSpan">A <see cref="TimeSpan"/> indicating the amount of time to buffer potential inputs.</param>
+        /// <returns>An <see cref="IStream{T}"/> that returns the first <typeparamref name="T"/> output after a <paramref name="timeSpan"/> of time for each group of <typeparamref name="T"/> inputs recieved during that time.</returns>
+        public static IStream<T> BufferFirst<T>(this IStream<T> stream, TimeSpan timeSpan)
+        {
+            return new BufferStream<T, T>(stream, timeSpan, ts => ts.FirstOrDefault());
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IStream{T}"/> that buffers inputs over a time given by a specified <see cref="TimeSpan"/>. The emitted <typeparamref name="T"/> values are the last from each buffered group.
+        /// </summary>
+        /// <typeparam name="T">The type of values returned by the parent <see cref="IStream{T}"/>.</typeparam>
+        /// <param name="stream">The parent <see cref="IStream{T}"/> producing <typeparamref name="T"/> values.</param>
+        /// <param name="timeSpan">A <see cref="TimeSpan"/> indicating the amount of time to buffer potential inputs.</param>
+        /// <returns>An <see cref="IStream{T}"/> that returns the last <typeparamref name="T"/> output after a <paramref name="timeSpan"/> of time for each group of <typeparamref name="T"/> inputs recieved during that time.</returns>
+        public static IStream<T> BufferLast<T>(this IStream<T> stream, TimeSpan timeSpan)
+        {
+            return new BufferStream<T, T>(stream, timeSpan, ts => ts.LastOrDefault());
+        }
+
+        #endregion
+        #region Tasks
+
+        /// <summary>
+        /// Creates an <see cref="IStream{T}"/> that executes the <see cref="Task{TResult}"/>s of the parent <see cref="IStream{T}"/> asynchronously, and returns the results as they arrive.
+        /// </summary>
+        /// <typeparam name="T">The type of the values this <see cref="IStream{T}"/> returns.</typeparam>
+        /// <param name="stream">The parent <see cref="IStream{T}"/> producing <see cref="Task{TResult}"/> values.</param>
+        /// <returns>An <see cref="IStream{T}"/> that returns resulting <typeparamref name="T"/> outputs asynchronously.</returns>        
+        public static IStream<T> Await<T>(this IStream<Task<T>> stream)
+        {
+            return new ParallelMapStream<Task<T>, T>(stream, t => t);
+        }
+
+        #endregion
+    }
+}

--- a/BassClefStudio.NET.Core/Streams/TimeStreams.cs
+++ b/BassClefStudio.NET.Core/Streams/TimeStreams.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Threading.Tasks;
+using System.Timers;
+
+namespace BassClefStudio.NET.Core.Streams
+{
+    /// <summary>
+    /// Represents an <see cref="IStream{T}"/> that buffers <typeparamref name="T1"/> inputs from a parent stream over a given span of time, and then returns a single <typeparamref name="T2"/> value.
+    /// </summary>
+    /// <typeparam name="T1">The type of values returned by the parent <see cref="IStream{T}"/>.</typeparam>
+    /// <typeparam name="T2">The type of the transformed values this <see cref="IStream{T}"/> returns.</typeparam>
+    public class BufferStream<T1,T2> : IStream<T2>
+    {
+        /// <inheritdoc/>
+        public bool Started { get; private set; } = false;
+
+        /// <summary>
+        /// The parent <see cref="IStream{T}"/> that produces parent objects.
+        /// </summary>
+        public IStream<T1> ParentStream { get; }
+
+        /// <inheritdoc/>
+        public event EventHandler<StreamValue<T2>> ValueEmitted;
+
+        /// <summary>
+        /// The <see cref="Timer"/> that this <see cref="BufferStream{T1,T2}"/> uses for buffering requests.
+        /// </summary>
+        public Timer BufferTimer { get; }
+
+        /// <summary>
+        /// The <see cref="Func{T, TResult}"/> that gets the <typeparamref name="T2"/> value from a buffered list of <typeparamref name="T1"/> items.
+        /// </summary>
+        public Func<IEnumerable<T1>, T2> BufferFunc { get; }
+
+        /// <summary>
+        /// A <see cref="TimeSpan"/> indicating the amount of time to buffer potential inputs.
+        /// </summary>
+        public TimeSpan BufferTime { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="BufferStream{T1, T2}"/>.
+        /// </summary>
+        /// <param name="parent">The parent <see cref="IStream{T}"/> that produces parent objects.</param>
+        /// <param name="bufferFunc">The <see cref="Func{T, TResult}"/> that gets the <typeparamref name="T2"/> value from a buffered list of <typeparamref name="T1"/> items.</param>
+        /// <param name="bufferTime">A <see cref="TimeSpan"/> indicating the amount of time to buffer potential inputs.</param>
+        public BufferStream(IStream<T1> parent, TimeSpan bufferTime, Func<IEnumerable<T1>, T2> bufferFunc)
+        {
+            ParentStream = parent;
+            BufferTime = bufferTime;
+            BufferFunc = bufferFunc;
+            BufferTimer = new Timer(bufferTime.TotalMilliseconds);
+            BufferTimer.Elapsed += TimerElapsed;
+        }
+
+        List<T1> bufferedItems = new List<T1>();
+
+        private void ParentValueEmitted(object sender, StreamValue<T1> e)
+        {
+            if(e.DataType == StreamValueType.Error)
+            {
+                ValueEmitted?.Invoke(this, new StreamValue<T2>(e.Error));
+            }
+            else if(e.DataType == StreamValueType.Completed)
+            {
+                ValueEmitted?.Invoke(this, new StreamValue<T2>());
+            }
+            else if(e.DataType == StreamValueType.Result)
+            {
+                bufferedItems.Add(e.Result);
+                if (!BufferTimer.Enabled)
+                {
+                    BufferTimer.Start();
+                }
+            }
+        }
+
+        private void TimerElapsed(object sender, ElapsedEventArgs e)
+        {
+            try
+            {
+                T2 result = BufferFunc(bufferedItems);
+                ValueEmitted?.Invoke(this, new StreamValue<T2>(result));
+            }
+            catch (Exception ex)
+            {
+                ValueEmitted?.Invoke(this, new StreamValue<T2>(ex));
+            }
+            BufferTimer.Stop();
+        }
+
+        /// <inheritdoc/>
+        public void Start()
+        {
+            if (!Started)
+            {
+                Started = true;
+                ParentStream.ValueEmitted += ParentValueEmitted;
+                ParentStream.Start();
+            }
+        }
+    }
+}

--- a/BassClefStudio.NET.Sync/BassClefStudio.NET.Sync.csproj
+++ b/BassClefStudio.NET.Sync/BassClefStudio.NET.Sync.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>BassClefStudio</Authors>
     <RepositoryUrl>https://github.com/bassclefstudio/.Net-Libraries.git</RepositoryUrl>
     <Description>A library for managing the connection between data stores (web APIs, files) and .NET objects.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.6.1</Version>
+    <Version>2.0.0</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/.Net-Libraries</PackageProjectUrl>
   </PropertyGroup>
 

--- a/BassClefStudio.NET.Tests/BassClefStudio.NET.Tests.csproj
+++ b/BassClefStudio.NET.Tests/BassClefStudio.NET.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+    <PackageReference Include="coverlet.collector" Version="1.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BassClefStudio.NET.Core\BassClefStudio.NET.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/BassClefStudio.NET.Tests/StreamTests.cs
+++ b/BassClefStudio.NET.Tests/StreamTests.cs
@@ -1,0 +1,246 @@
+﻿using BassClefStudio.NET.Core.Streams;
+using BassClefStudio.NET.Core;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BassClefStudio.AppModel.Tests
+{
+    [TestClass]
+    public class StreamTests
+    {
+        #region Binding
+
+        private static MyClass CreateTestObject()
+        {
+            return new MyClass()
+            {
+                Property = new MyPropertyClass()
+                {
+                    Name = "Test 1",
+                    Keys = new ObservableCollection<string>() { "Test 1" }
+                }
+            };
+        }
+
+        private static void TestBinding(Func<MyClass, IStream<string>> getBinding)
+        {
+            var myObject = CreateTestObject();
+            string value = null;
+            IStream<string> nameBinding = getBinding(myObject)
+                .BindResult(v => value = v);
+            nameBinding.Start();
+
+            myObject.Property.Name = "Test 2";
+            Assert.IsNotNull(value, "ValueChanged event was not fired.");
+            Assert.AreEqual(myObject.Property.Name, value, "Incorrect StoredValue on nameBinding.");
+
+            value = null;
+            myObject.Property = new MyPropertyClass()
+            {
+                Name = "Test 3"
+            };
+            Assert.IsNotNull(value, "ValueChanged event was not fired.");
+            Assert.AreEqual(myObject.Property.Name, value, "Incorrect StoredValue on nameBinding.");
+        }
+
+        [TestMethod]
+        public void TestPropertyBinding()
+        {
+            TestBinding(myObject => myObject.AsStream()
+                .Property(m => m.Property)
+                .Property(p => p.Name));
+            //// Strongly-typed - think {x:Bind Property.Name}
+        }
+
+        [TestMethod]
+        public void TestReflectionBinding()
+        {
+            TestBinding(myObject => myObject.AsStream()
+                .Property<MyClass, string>("Property.Name"));
+            //// Reflection - weakly-typed - think {Binding Property.Name}
+        }
+
+        [TestMethod]
+        public void TestBadReflectionPath()
+        {
+            var myObject = CreateTestObject();
+            Assert.ThrowsException<StreamException>(() =>
+                myObject.AsStream()
+                .Property<MyClass, string>("Property.Blah"));
+            //// Reflection - weakly-typed - think {Binding Property.Blah} (where the property name doesn't exist).
+        }
+
+        [TestMethod]
+        public void TestNullSets()
+        {
+            var a = new MyPropertyClass()
+            {
+                Name = "Fred",
+                Keys = null
+            };
+
+            var b = new MyPropertyClass()
+            {
+                Name = "George",
+                Keys = null
+            };
+
+            var myObject = new MyClass()
+            {
+                Property = a
+            };
+
+            int register = 0;
+            IStream<ObservableCollection<string>> keysBinding = myObject
+                .AsStream().Property(m => m.Property).Property(p => p.Keys)
+                .BindResult(v => register++);
+            keysBinding.Start();
+
+            myObject.Property = b;
+            Assert.AreEqual(0, register, "ValueChanged event was accidentally fired.");
+        }
+
+        #endregion
+        #region Linq
+
+        [TestMethod]
+        public void TestFilter()
+        {
+            string[] values = new string[] { "wow!", "hello", "cool!", "great", "awesome!" };
+            List<string> results = new List<string>();
+            var stream = new SourceStream<string>(values)
+                .Where(s => s.Last() == '!')
+                .BindResult(results.Add);
+            stream.Start();
+            Assert.AreEqual(3, results.Count, "Result does not contain expected number of items.");
+            Assert.IsTrue(results.SequenceEqual(new string[] { values[0], values[2], values[4] }));
+        }
+
+        [TestMethod]
+        public void TestAggregateCounter()
+        {
+            int length = 8;
+            int number = 0;
+            var source = SourceStream<string>.Repeat("Hello World!", length)
+                .Join(new SourceStream<string>(new StreamValue<string>()));
+            var stream = source
+                .Aggregate<string, int>((n, s) => n + 1)
+                .BindResult(n => number = n);
+            stream.Start();
+            Assert.AreEqual(length, number, "Aggregate was not expected value.");
+        }
+
+        [TestMethod]
+        public void TestSum()
+        {
+            int length = 8;
+            int number = 0;
+            var stream = SourceStream<int>.Repeat(2, length)
+                .Sum()
+                .BindResult(n => number = n);
+            stream.Start();
+            Assert.AreEqual(length * 2, number, "Sum was not expected value.");
+        }
+
+        [TestMethod]
+        public void TestCount()
+        {
+            int length = 8;
+            int number = 0;
+            var stream = SourceStream<string>.Repeat("Hello World!", length)
+                .Count()
+                .BindResult(n => number = n);
+            stream.Start();
+            Assert.AreEqual(length, number, "Count was not expected value.");
+        }
+
+        [TestMethod]
+        public void TestJoin()
+        {
+            int length = 8;
+            List<int> numbers = new List<int>();
+            var streamA = SourceStream<int>.CountStream(1, length);
+            var streamB = new SourceStream<int>(2);
+            IStream<int> join = streamB
+                .Join(streamA, (i, s) => i + s)
+                .BindResult(n => numbers.Add(n));
+            join.Start();
+            Assert.AreEqual(numbers.Count, length + 1, "Returned values were of an unexpected length");
+            Assert.IsTrue(numbers.SequenceEqual(Enumerable.Range(2, length + 1)), "Sequence of returned values was unexpected.");
+        }
+
+        [TestMethod]
+        public void TestUnique()
+        {
+            int length = 8;
+            int number = 0;
+            var source = SourceStream<string>.Repeat("Hello World!", length)
+                .Join(new SourceStream<string>(new StreamValue<string>()));
+            var stream = source
+                .Unique()
+                .BindResult(n => number++);
+            stream.Start();
+            Assert.AreEqual(1, number, "Number of unique items was invalid.");
+        }
+
+        [TestMethod]
+        public void TestRec()
+        {
+            int length = 4;
+            int number = 0;
+            SourceStream<int> source = null;
+            Func<SourceStream<int>> recSource = () => source;
+            IStream<int> stream = recSource.Rec()
+                .Count()
+                .BindResult(n => number = n);
+            source = SourceStream<int>.Repeat(1, length);
+            stream.Start();
+            Assert.AreEqual(number, length, "Lazy stream evaluation returned the incorrect count.");
+        }
+
+        #endregion
+        #region Sources
+
+        [TestMethod]
+        public void EmptySource()
+        {
+            SourceStream<string> source = new SourceStream<string>();
+            string value = null;
+            source.BindResult(s => value = s);
+            source.Start();
+            Assert.AreEqual(null, value, "SourceStream unintentionally emitted a value.");
+        }
+
+        [TestMethod]
+        public void ListSource()
+        {
+            SourceStream<string> source = new SourceStream<string>("hello", "world!");
+            string value = null;
+            source.BindResult(s => value = s);
+            source.Start();
+            Assert.IsNotNull(value, "SourceStream failed to emit a value.");
+            Assert.AreEqual("world!", value, "SourceStream's last emitted value was unexpected.");
+        }
+
+        #endregion
+    }
+
+    class MyClass : Observable
+    {
+        private MyPropertyClass property;
+        public MyPropertyClass Property { get => property; set => Set(ref property, value); }
+    }
+
+    class MyPropertyClass : Observable
+    {
+        private string name;
+        public string Name { get => name; set => Set(ref name, value); }
+
+        public ObservableCollection<string> Keys { get; set; }
+    }
+}

--- a/BassClefStudio.NET.sln
+++ b/BassClefStudio.NET.sln
@@ -5,7 +5,9 @@ VisualStudioVersion = 16.0.30128.74
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BassClefStudio.NET.Core", "BassClefStudio.NET.Core\BassClefStudio.NET.Core.csproj", "{DCA13C5A-8BA2-4624-B070-3C6CDFDBF476}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BassClefStudio.NET.Sync", "BassClefStudio.NET.Sync\BassClefStudio.NET.Sync.csproj", "{7D7A7DAD-BA5E-4DA2-9581-C7D9BE907A5A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BassClefStudio.NET.Sync", "BassClefStudio.NET.Sync\BassClefStudio.NET.Sync.csproj", "{7D7A7DAD-BA5E-4DA2-9581-C7D9BE907A5A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BassClefStudio.NET.Tests", "BassClefStudio.NET.Tests\BassClefStudio.NET.Tests.csproj", "{F0BCCC46-945E-4D94-9683-87F9ED3C4E4E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{7D7A7DAD-BA5E-4DA2-9581-C7D9BE907A5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7D7A7DAD-BA5E-4DA2-9581-C7D9BE907A5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7D7A7DAD-BA5E-4DA2-9581-C7D9BE907A5A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F0BCCC46-945E-4D94-9683-87F9ED3C4E4E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F0BCCC46-945E-4D94-9683-87F9ED3C4E4E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F0BCCC46-945E-4D94-9683-87F9ED3C4E4E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F0BCCC46-945E-4D94-9683-87F9ED3C4E4E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
These have been moved to the BassClefStudio.NET library from [BassClefStudio.AppModel](https://github.com/bassclefstudio/AppModel/).

This library was updated to use .NET Standard 2.0, and thus a new major package version number was added - v2.0.0.

Closes #56.