### PR TITLE
Added new Take<T1,T2> stream extension method

### DIFF
--- a/BassClefStudio.NET.Core/BassClefStudio.NET.Core.csproj
+++ b/BassClefStudio.NET.Core/BassClefStudio.NET.Core.csproj
@@ -7,12 +7,8 @@
     <Company>BassClefStudio</Company>
     <Description>Contains helper classes and extension methods for creating .NET projects.</Description>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>2.0.2</Version>
+    <Version>2.0.3</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageProjectUrl>https://github.com/bassclefstudio/.Net-Libraries</PackageProjectUrl>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Folder Include="Streams\" />
-  </ItemGroup>
 </Project>

--- a/BassClefStudio.NET.Core/Streams/StreamExtensions.cs
+++ b/BassClefStudio.NET.Core/Streams/StreamExtensions.cs
@@ -130,6 +130,36 @@ namespace BassClefStudio.NET.Core.Streams
         }
 
         #endregion
+        #region Take
+
+        /// <summary>
+        /// Creates an <see cref="IStream{T}"/> that transforms some number of values from the given <see cref="IStream{T}"/> into <typeparamref name="T2"/> values.
+        /// </summary>
+        /// <typeparam name="T1">The type of values returned by the parent <see cref="IStream{T}"/>.</typeparam>
+        /// <typeparam name="T2">The type of the values this <see cref="IStream{T}"/> returns.</typeparam>
+        /// <param name="stream">The parent <see cref="IStream{T}"/> producing <typeparamref name="T1"/> values.</param>
+        /// <param name="produceFunc">The function that returns a new <typeparamref name="T2"/> from the last <paramref name="takeSize"/> <typeparamref name="T1"/> values emitted by the parent <see cref="IStream{T}"/>.</param>
+        /// <param name="takeSize">The number of <typeparamref name="T1"/> items to be provided as inputs to the <paramref name="produceFunc"/> function.</param>
+        /// <returns>An <see cref="IStream{T}"/> that returns resulting <typeparamref name="T2"/> values.</returns>
+        public static IStream<T2> Take<T1, T2>(this IStream<T1> stream, Func<T1[], T2> produceFunc, int takeSize = 2)
+        {
+            return new TakeStream<T1, T2>(stream, produceFunc, takeSize);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="IStream{T}"/> that transforms the last two values from the given <see cref="IStream{T}"/> into a single <typeparamref name="T2"/> value.
+        /// </summary>
+        /// <typeparam name="T1">The type of values returned by the parent <see cref="IStream{T}"/>.</typeparam>
+        /// <typeparam name="T2">The type of the values this <see cref="IStream{T}"/> returns.</typeparam>
+        /// <param name="stream">The parent <see cref="IStream{T}"/> producing <typeparamref name="T1"/> values.</param>
+        /// <param name="produceFunc">The function that returns a new <typeparamref name="T2"/> from the last two <typeparamref name="T1"/> values emitted by the parent <see cref="IStream{T}"/>.</param>
+        /// <returns>An <see cref="IStream{T}"/> that returns resulting <typeparamref name="T2"/> values.</returns>
+        public static IStream<T2> Take<T1, T2>(this IStream<T1> stream, Func<T1, T1, T2> produceFunc)
+        {
+            return new TakeStream<T1, T2>(stream, ts => produceFunc(ts[0], ts[1]));
+        }
+
+        #endregion
         #region Join
 
         /// <summary>

--- a/BassClefStudio.NET.Core/Streams/TakeStream.cs
+++ b/BassClefStudio.NET.Core/Streams/TakeStream.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BassClefStudio.NET.Core.Streams
+{
+    /// <summary>
+    /// An <see cref="IStream{T}"/> that manages incoming inputs from a parent <see cref="IStream{T}"/> with previously emitted items, allowing for the comparing of previous values.
+    /// </summary>
+    /// <typeparam name="T1">The type of values returned by the parent <see cref="IStream{T}"/>.</typeparam>
+    /// <typeparam name="T2">The type of output values this <see cref="IStream{T}"/> produces.</typeparam>
+    public class TakeStream<T1, T2> : IStream<T2>
+    {
+        /// <inheritdoc/>
+        public bool Started { get; private set; }
+
+        /// <summary>
+        /// The previously emitted value from <see cref="ParentStream"/>.
+        /// </summary>
+        private Queue<T1> PreviousValues { get; set; }
+
+        /// <summary>
+        /// The <see cref="int"/> number of items from the <see cref="ParentStream"/> that should be queued before/when making calls to the <see cref="ProduceFunc"/> is called to create <typeparamref name="T2"/> values.
+        /// </summary>
+        public int TakeLength { get; }
+
+        /// <summary>
+        /// A <see cref="Func{T, TResult}"/> that takes in the incoming and previous <typeparamref name="T1"/> inputs and returns a <typeparamref name="T2"/> value that to be emitted.
+        /// </summary>
+        public Func<T1[], T2> ProduceFunc { get; }
+
+        /// <summary>
+        /// The parent <see cref="IStream{T}"/> this <see cref="DistinctStream{T}"/> is based on.
+        /// </summary>
+        public IStream<T1> ParentStream { get; }
+
+        /// <inheritdoc/>
+        public event EventHandler<StreamValue<T2>> ValueEmitted;
+
+        /// <summary>
+        /// Creates a new <see cref="DistinctStream{T}"/>.
+        /// </summary>
+        /// <param name="parentStream">The parent <see cref="IStream{T}"/> this <see cref="TakeStream{T1, T2}"/> is based on.</param>
+        /// <param name="produceFunc">A <see cref="Func{T, TResult}"/> that takes in the incoming and previous <typeparamref name="T1"/> inputs and returns a <typeparamref name="T2"/> value that to be emitted.</param>
+        /// <param name="takeLength">The <see cref="int"/> number of items from the <see cref="ParentStream"/> that should be queued before/when making calls to the <see cref="ProduceFunc"/> is called to create <typeparamref name="T2"/> values.</param>
+        public TakeStream(IStream<T1> parentStream, Func<T1[], T2> produceFunc, int takeLength = 2)
+        {
+            ParentStream = parentStream;
+            ProduceFunc = produceFunc;
+            TakeLength = takeLength;
+        }
+
+        /// <inheritdoc/>
+        public void Start()
+        {
+            if (!Started)
+            {
+                Started = true;
+                PreviousValues = new Queue<T1>();
+                ParentStream.ValueEmitted += ParentValueEmitted;
+                ParentStream.Start();
+            }
+        }
+
+        private void ParentValueEmitted(object sender, StreamValue<T1> e)
+        {
+            if (e.DataType == StreamValueType.Completed)
+            {
+                ValueEmitted?.Invoke(this, new StreamValue<T2>());
+            }
+            else if (e.DataType == StreamValueType.Error)
+            {
+                ValueEmitted?.Invoke(this, new StreamValue<T2>(e.Error));
+            }
+            else if (e.DataType == StreamValueType.Result)
+            {
+                try
+                {
+                    PreviousValues.Enqueue(e.Result);
+                    if (PreviousValues.Count > TakeLength)
+                    {
+                        PreviousValues.Dequeue();
+                    }
+
+                    if (PreviousValues.Count == TakeLength)
+                    {
+                        ValueEmitted?.Invoke(this, new StreamValue<T2>(ProduceFunc(PreviousValues.ToArray())));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    ValueEmitted?.Invoke(this, new StreamValue<T2>(ex));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This allows for an `IStream<T>` to be created that depends on the last _n_ items emitted by a parent stream, utilizing a new `TakeStream<T1,T2>` class that manages a `Queue<T1>` of previously emitted values as inputs for a transformation function.

Closes #61.