### PR TITLE
Behind-the-scenes improvements to the IStream<T> interface and extension methods

### DIFF
--- a/BassClefStudio.NET.Core/BassClefStudio.NET.Core.csproj
+++ b/BassClefStudio.NET.Core/BassClefStudio.NET.Core.csproj
@@ -7,7 +7,7 @@
     <Company>BassClefStudio</Company>
     <Description>Contains helper classes and extension methods for creating .NET projects.</Description>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>2.0.3</Version>
+    <Version>2.0.4</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageProjectUrl>https://github.com/bassclefstudio/.Net-Libraries</PackageProjectUrl>
   </PropertyGroup>

--- a/BassClefStudio.NET.Core/Streams/ChildStreams.cs
+++ b/BassClefStudio.NET.Core/Streams/ChildStreams.cs
@@ -18,7 +18,7 @@ namespace BassClefStudio.NET.Core.Streams
         public bool Started { get; private set; } = false;
 
         /// <inheritdoc/>
-        public event EventHandler<StreamValue<T2>> ValueEmitted;
+        public StreamBinding<T2> ValueEmitted { get; }
 
         /// <summary>
         /// The parent <see cref="IStream{T}"/> this <see cref="ChildStream{T1, T2}"/> is based on.
@@ -37,6 +37,7 @@ namespace BassClefStudio.NET.Core.Streams
         /// <param name="parent"></param>
         public ChildStream(IStream<T1> parent)
         {
+            ValueEmitted = new StreamBinding<T2>();
             ParentStream = parent;
         }
 
@@ -46,31 +47,31 @@ namespace BassClefStudio.NET.Core.Streams
             if (!Started)
             {
                 Started = true;
-                ParentStream.ValueEmitted += ParentValueEmitted;
+                ParentStream.ValueEmitted.AddAction(ParentValueEmitted);
                 ParentStream.Start();
             }
         }
 
-        private void ParentValueEmitted(object sender, StreamValue<T1> e)
+        private void ParentValueEmitted(StreamValue<T1> e)
         {
             if (e.DataType == StreamValueType.Completed)
             {
-                ValueEmitted?.Invoke(this, new StreamValue<T2>());
+                ValueEmitted.EmitValue(new StreamValue<T2>());
             }
             else if (e.DataType == StreamValueType.Error)
             {
-                ValueEmitted?.Invoke(this, new StreamValue<T2>(e.Error));
+                ValueEmitted.EmitValue(new StreamValue<T2>(e.Error));
             }
             else if (e.DataType == StreamValueType.Result)
             {
                 try
                 {
                     var output = ProduceValue(e.Result);
-                    ValueEmitted?.Invoke(this, new StreamValue<T2>(output));
+                    ValueEmitted.EmitValue(new StreamValue<T2>(output));
                 }
                 catch (Exception ex)
                 {
-                    ValueEmitted?.Invoke(this, new StreamValue<T2>(ex));
+                    ValueEmitted.EmitValue(new StreamValue<T2>(ex));
                 }
             }
         }

--- a/BassClefStudio.NET.Core/Streams/ConcatStream.cs
+++ b/BassClefStudio.NET.Core/Streams/ConcatStream.cs
@@ -20,7 +20,7 @@ namespace BassClefStudio.NET.Core.Streams
         public IStream<T>[] ParentStreams { get; }
 
         /// <inheritdoc/>
-        public event EventHandler<StreamValue<T>> ValueEmitted;
+        public StreamBinding<T> ValueEmitted { get; }
 
         /// <summary>
         /// Creates a new <see cref="ConcatStream{T}"/>.
@@ -28,6 +28,7 @@ namespace BassClefStudio.NET.Core.Streams
         /// <param name="parents">A collection of <see cref="IStream{T}"/> parent streams, from which emitted values are passed to the <see cref="ConcatStream{T}"/>.</param>
         public ConcatStream(params IStream<T>[] parents)
         {
+            ValueEmitted = new StreamBinding<T>();
             ParentStreams = parents;
         }
 
@@ -37,6 +38,7 @@ namespace BassClefStudio.NET.Core.Streams
         /// <param name="parents">A collection of <see cref="IStream{T}"/> parent streams, from which emitted values are passed to the <see cref="ConcatStream{T}"/>.</param>
         public ConcatStream(IEnumerable<IStream<T>> parents)
         {
+            ValueEmitted = new StreamBinding<T>();
             ParentStreams = parents.ToArray();
         }
 
@@ -48,7 +50,7 @@ namespace BassClefStudio.NET.Core.Streams
                 Started = true;
                 foreach (var p in ParentStreams)
                 {
-                    p.ValueEmitted += ParentValueEmitted;
+                    p.ValueEmitted.AddAction(ParentValueEmitted);
                 }
 
                 foreach (var p in ParentStreams)
@@ -58,9 +60,9 @@ namespace BassClefStudio.NET.Core.Streams
             }
         }
 
-        private void ParentValueEmitted(object sender, StreamValue<T> e)
+        private void ParentValueEmitted(StreamValue<T> e)
         {
-            ValueEmitted?.Invoke(this, e);
+            ValueEmitted.EmitValue(e);
         }
     }
 }

--- a/BassClefStudio.NET.Core/Streams/RecStream.cs
+++ b/BassClefStudio.NET.Core/Streams/RecStream.cs
@@ -24,7 +24,7 @@ namespace BassClefStudio.NET.Core.Streams
         private IStream<T> ParentStream { get; set; }
 
         /// <inheritdoc/>
-        public event EventHandler<StreamValue<T>> ValueEmitted;
+        public StreamBinding<T> ValueEmitted { get; }
 
         /// <summary>
         /// Creates a new <see cref="RecStream{T}"/>.
@@ -32,6 +32,7 @@ namespace BassClefStudio.NET.Core.Streams
         /// <param name="getStream">A <see cref="Func{TResult}"/> that will, when evaluated, return the parent <see cref="IStream{T}"/>.</param>
         public RecStream(Func<IStream<T>> getStream)
         {
+            ValueEmitted = new StreamBinding<T>();
             GetStream = getStream;
         }
 
@@ -42,14 +43,14 @@ namespace BassClefStudio.NET.Core.Streams
             {
                 Started = true;
                 ParentStream = GetStream();
-                ParentStream.ValueEmitted += ParentValueEmitted;
+                ParentStream.ValueEmitted.AddAction(ParentValueEmitted);
                 ParentStream.Start();
             }
         }
 
-        private void ParentValueEmitted(object sender, StreamValue<T> e)
+        private void ParentValueEmitted(StreamValue<T> e)
         {
-            ValueEmitted?.Invoke(this, e);
+            ValueEmitted.EmitValue(e);
         }
     }
 }

--- a/BassClefStudio.NET.Core/Streams/SourceStream.cs
+++ b/BassClefStudio.NET.Core/Streams/SourceStream.cs
@@ -17,13 +17,14 @@ namespace BassClefStudio.NET.Core.Streams
         public bool Started { get; private set; } = false;
 
         /// <inheritdoc/>
-        public event EventHandler<StreamValue<T>> ValueEmitted;
+        public StreamBinding<T> ValueEmitted { get; }
 
         /// <summary>
         /// Creates an empty <see cref="SourceStream{T}"/>.
         /// </summary>
         public SourceStream()
         {
+            ValueEmitted = new StreamBinding<T>();
             StartInputs = Array.Empty<StreamValue<T>>();
         }
 
@@ -38,6 +39,7 @@ namespace BassClefStudio.NET.Core.Streams
         /// <param name="inputs">A collection of <see cref="StreamValue{T}"/> inputs that will be sent onto the <see cref="SourceStream{T}"/> when <see cref="IStream{T}.Start"/> is called.</param>
         public SourceStream(IEnumerable<StreamValue<T>> inputs)
         {
+            ValueEmitted = new StreamBinding<T>();
             StartInputs = inputs;
         }
 
@@ -47,6 +49,7 @@ namespace BassClefStudio.NET.Core.Streams
         /// <param name="inputs">A collection of <see cref="StreamValue{T}"/> inputs that will be sent onto the <see cref="SourceStream{T}"/> when <see cref="IStream{T}.Start"/> is called.</param>
         public SourceStream(params StreamValue<T>[] inputs)
         {
+            ValueEmitted = new StreamBinding<T>();
             StartInputs = inputs;
         }
 
@@ -56,6 +59,7 @@ namespace BassClefStudio.NET.Core.Streams
         /// <param name="inputs">A collection of <typeparamref name="T"/> inputs that will be sent onto the <see cref="SourceStream{T}"/> when <see cref="IStream{T}.Start"/> is called.</param>
         public SourceStream(IEnumerable<T> inputs)
         {
+            ValueEmitted = new StreamBinding<T>();
             StartInputs = inputs.Select(t => new StreamValue<T>(t));
         }
 
@@ -65,6 +69,7 @@ namespace BassClefStudio.NET.Core.Streams
         /// <param name="inputs">A collection of <typeparamref name="T"/> inputs that will be sent onto the <see cref="SourceStream{T}"/> when <see cref="IStream{T}.Start"/> is called.</param>
         public SourceStream(params T[] inputs)
         {
+            ValueEmitted = new StreamBinding<T>();
             StartInputs = inputs.Select(t => new StreamValue<T>(t));
         }
 
@@ -106,7 +111,7 @@ namespace BassClefStudio.NET.Core.Streams
         /// <param name="input">The pertinent <typeparamref name="T"/> value.</param>
         public void EmitValue(StreamValue<T> input)
         {
-            ValueEmitted?.Invoke(this, input);
+            ValueEmitted.EmitValue(input);
         }
 
         /// <summary>
@@ -127,7 +132,7 @@ namespace BassClefStudio.NET.Core.Streams
         /// <param name="input">The pertinent <typeparamref name="T"/> value.</param>
         public void EmitValue(T input)
         {
-            ValueEmitted?.Invoke(this, new StreamValue<T>(input));
+            ValueEmitted.EmitValue(new StreamValue<T>(input));
         }
 
         /// <summary>
@@ -148,7 +153,7 @@ namespace BassClefStudio.NET.Core.Streams
         /// <param name="ex">The <see cref="Exception"/> describing the error.</param>
         public void ThrowError(Exception ex)
         {
-            ValueEmitted?.Invoke(this, new StreamValue<T>(ex));
+            ValueEmitted.EmitValue(new StreamValue<T>(ex));
         }
 
         /// <summary>
@@ -156,7 +161,7 @@ namespace BassClefStudio.NET.Core.Streams
         /// </summary>
         public void Complete()
         {
-            ValueEmitted?.Invoke(this, new StreamValue<T>());
+            ValueEmitted.EmitValue(new StreamValue<T>());
         }
     }
 }

--- a/BassClefStudio.NET.Core/Streams/StreamExtensions.cs
+++ b/BassClefStudio.NET.Core/Streams/StreamExtensions.cs
@@ -305,8 +305,9 @@ namespace BassClefStudio.NET.Core.Streams
         /// <typeparam name="T">The type of values emitted by this <see cref="IStream{T}"/>.</typeparam>
         /// <param name="stream">The <see cref="IStream{T}"/> stream to bind to.</param>
         /// <param name="action">An action that takes in an input <typeparamref name="T"/> value and will be executed every time the <paramref name="stream"/> emits a value of <see cref="StreamValueType.Result"/>.</param>
+        /// <param name="start">A <see cref="bool"/> indicating whether the <see cref="IStream{T}"/> should be automatically started.</param>
         /// <returns>The input <see cref="IStream{T}"/> <paramref name="stream"/>.</returns>
-        public static IStream<T> BindResult<T>(this IStream<T> stream, Action<T> action)
+        public static IStream<T> BindResult<T>(this IStream<T> stream, Action<T> action, bool start = true)
         {
             stream.ValueEmitted.AddAction(e =>
                 {
@@ -315,6 +316,11 @@ namespace BassClefStudio.NET.Core.Streams
                         action(e.Result);
                     }
                 });
+
+            if(start)
+            {
+                stream.Start();
+            }
             return stream;
         }
 
@@ -324,8 +330,9 @@ namespace BassClefStudio.NET.Core.Streams
         /// <typeparam name="T">The type of values emitted by this <see cref="IStream{T}"/>.</typeparam>
         /// <param name="stream">The <see cref="IStream{T}"/> stream to bind to.</param>
         /// <param name="action">An action that takes in an input <typeparamref name="T"/> value and will be executed every time the <paramref name="stream"/> emits a value of <see cref="StreamValueType.Result"/>.</param>
+        /// <param name="start">A <see cref="bool"/> indicating whether the <see cref="IStream{T}"/> should be automatically started.</param>
         /// <returns>The input <see cref="IStream{T}"/> <paramref name="stream"/>.</returns>
-        public static IStream<T> BindResult<T>(this IStream<T> stream, Func<T, Task> action)
+        public static IStream<T> BindResult<T>(this IStream<T> stream, Func<T, Task> action, bool start = true)
         {
             async Task<T> RunReturn(T input)
             {
@@ -333,7 +340,12 @@ namespace BassClefStudio.NET.Core.Streams
                 return input;
             }
 
-            return stream.Select(RunReturn);
+            IStream<T> newStream = stream.Select(RunReturn);
+            if (start)
+            {
+                newStream.Start();
+            }
+            return newStream;
         }
 
         /// <summary>

--- a/BassClefStudio.NET.Core/Streams/StreamExtensions.cs
+++ b/BassClefStudio.NET.Core/Streams/StreamExtensions.cs
@@ -303,78 +303,18 @@ namespace BassClefStudio.NET.Core.Streams
         /// Binds the incoming <typeparamref name="T"/> results from an <see cref="IStream{T}"/> to a given <see cref="Action{T}"/>.
         /// </summary>
         /// <typeparam name="T">The type of values emitted by this <see cref="IStream{T}"/>.</typeparam>
-        /// <typeparam name="TStream">The type of <see cref="IStream{T}"/> being bound to.</typeparam>
-        /// <param name="stream">The <see cref="IStream{T}"/> stream to bind to.</param>
-        /// <param name="action">An action that takes in an input <typeparamref name="T"/> value and will be executed every time the <paramref name="stream"/> emits a value of <see cref="StreamValueType.Result"/>.</param>
-        /// <returns>The input <see cref="IStream{T}"/> <paramref name="stream"/>.</returns>
-        public static TStream BindResult<T, TStream>(this TStream stream, Action<T> action) where TStream : IStream<T>
-        {
-            stream.ValueEmitted += (s, e) =>
-            {
-                if(e.DataType == StreamValueType.Result)
-                {
-                    action(e.Result);
-                }
-            };
-            return stream;
-        }
-
-        /// <summary>
-        /// Binds any incoming <see cref="Exception"/>s from an <see cref="IStream{T}"/> to a given <see cref="Action{T}"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of values emitted by this <see cref="IStream{T}"/>.</typeparam>
-        /// <typeparam name="TStream">The type of <see cref="IStream{T}"/> being bound to.</typeparam>
-        /// <param name="stream">The <see cref="IStream{T}"/> stream to bind to.</param>
-        /// <param name="action">An action that takes in an input <see cref="Exception"/> and will be executed every time the <paramref name="stream"/> emits a value of <see cref="StreamValueType.Error"/>.</param>
-        /// <returns>The input <see cref="IStream{T}"/> <paramref name="stream"/>.</returns>
-        public static TStream BindError<T, TStream>(this TStream stream, Action<Exception> action) where TStream : IStream<T>
-        {
-            stream.ValueEmitted += (s, e) =>
-            {
-                if (e.DataType == StreamValueType.Error)
-                {
-                    action(e.Error);
-                }
-            };
-            return stream;
-        }
-
-        /// <summary>
-        /// Binds the completion of an <see cref="IStream{T}"/> to a given <see cref="Action"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of values emitted by this <see cref="IStream{T}"/>.</typeparam>
-        /// <typeparam name="TStream">The type of <see cref="IStream{T}"/> being bound to.</typeparam>
-        /// <param name="stream">The <see cref="IStream{T}"/> stream to bind to.</param>
-        /// <param name="action">An action that will be executed every time the <paramref name="stream"/> emits a value of <see cref="StreamValueType.Completed"/>.</param>
-        /// <returns>The input <see cref="IStream{T}"/> <paramref name="stream"/>.</returns>
-        public static TStream BindComplete<T, TStream>(this TStream stream, Action action) where TStream : IStream<T>
-        {
-            stream.ValueEmitted += (s, e) =>
-            {
-                if (e.DataType == StreamValueType.Completed)
-                {
-                    action();
-                }
-            };
-            return stream;
-        }
-
-        /// <summary>
-        /// Binds the incoming <typeparamref name="T"/> results from an <see cref="IStream{T}"/> to a given <see cref="Action{T}"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of values emitted by this <see cref="IStream{T}"/>.</typeparam>
         /// <param name="stream">The <see cref="IStream{T}"/> stream to bind to.</param>
         /// <param name="action">An action that takes in an input <typeparamref name="T"/> value and will be executed every time the <paramref name="stream"/> emits a value of <see cref="StreamValueType.Result"/>.</param>
         /// <returns>The input <see cref="IStream{T}"/> <paramref name="stream"/>.</returns>
         public static IStream<T> BindResult<T>(this IStream<T> stream, Action<T> action)
         {
-            stream.ValueEmitted += (s, e) =>
-            {
-                if (e.DataType == StreamValueType.Result)
+            stream.ValueEmitted.AddAction(e =>
                 {
-                    action(e.Result);
-                }
-            };
+                    if (e.DataType == StreamValueType.Result)
+                    {
+                        action(e.Result);
+                    }
+                });
             return stream;
         }
 
@@ -387,13 +327,13 @@ namespace BassClefStudio.NET.Core.Streams
         /// <returns>The input <see cref="IStream{T}"/> <paramref name="stream"/>.</returns>
         public static IStream<T> BindError<T>(this IStream<T> stream, Action<Exception> action)
         {
-            stream.ValueEmitted += (s, e) =>
-            {
-                if (e.DataType == StreamValueType.Error)
+            stream.ValueEmitted.AddAction(e =>
                 {
-                    action(e.Error);
-                }
-            };
+                    if (e.DataType == StreamValueType.Error)
+                    {
+                        action(e.Error);
+                    }
+                });
             return stream;
         }
 
@@ -406,13 +346,13 @@ namespace BassClefStudio.NET.Core.Streams
         /// <returns>The input <see cref="IStream{T}"/> <paramref name="stream"/>.</returns>
         public static IStream<T> BindComplete<T>(this IStream<T> stream, Action action)
         {
-            stream.ValueEmitted += (s, e) =>
-            {
-                if (e.DataType == StreamValueType.Completed)
+            stream.ValueEmitted.AddAction(e =>
                 {
-                    action();
-                }
-            };
+                    if (e.DataType == StreamValueType.Completed)
+                    {
+                        action();
+                    }
+                });
             return stream;
         }
 

--- a/BassClefStudio.NET.Core/Streams/StreamExtensions.cs
+++ b/BassClefStudio.NET.Core/Streams/StreamExtensions.cs
@@ -319,6 +319,24 @@ namespace BassClefStudio.NET.Core.Streams
         }
 
         /// <summary>
+        /// Binds the incoming <typeparamref name="T"/> results from an <see cref="IStream{T}"/> to a given asynchronous <see cref="Task"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of values emitted by this <see cref="IStream{T}"/>.</typeparam>
+        /// <param name="stream">The <see cref="IStream{T}"/> stream to bind to.</param>
+        /// <param name="action">An action that takes in an input <typeparamref name="T"/> value and will be executed every time the <paramref name="stream"/> emits a value of <see cref="StreamValueType.Result"/>.</param>
+        /// <returns>The input <see cref="IStream{T}"/> <paramref name="stream"/>.</returns>
+        public static IStream<T> BindResult<T>(this IStream<T> stream, Func<T, Task> action)
+        {
+            async Task<T> RunReturn(T input)
+            {
+                await action(input);
+                return input;
+            }
+
+            return stream.Select(RunReturn);
+        }
+
+        /// <summary>
         /// Binds any incoming <see cref="Exception"/>s from an <see cref="IStream{T}"/> to a given <see cref="Action{T}"/>.
         /// </summary>
         /// <typeparam name="T">The type of values emitted by this <see cref="IStream{T}"/>.</typeparam>

--- a/BassClefStudio.NET.Core/Streams/StreamValue.cs
+++ b/BassClefStudio.NET.Core/Streams/StreamValue.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BassClefStudio.NET.Core.Streams
+{
+    /// <summary>
+    /// A struct that provides some value of type <typeparamref name="T"/> if successful, else contains information about the error that occurred.
+    /// </summary>
+    /// <typeparam name="T">The type of value this <see cref="StreamValue{T}"/> could encapsulate.</typeparam>
+    public struct StreamValue<T>
+    {
+        /// <summary>
+        /// A <see cref="StreamValueType"/> indicating what type of result this <see cref="StreamValue{T}"/> encapsulates.
+        /// </summary>
+        public StreamValueType DataType { get; private set; }
+
+        private T result;
+        /// <summary>
+        /// The <typeparamref name="T"/> result, if <see cref="DataType"/> is set to <see cref="StreamValueType.Result"/> true.
+        /// </summary>
+        public T Result
+        {
+            get
+            {
+                if (DataType == StreamValueType.Result)
+                {
+                    return result;
+                }
+                else
+                {
+                    throw new InvalidOperationException("Cannot retrieve the value of Maybe<T>.Result if DataType is not 'Result'.");
+                }
+            }
+        }
+
+        private Exception error;
+        /// <summary>
+        /// If <see cref="DataType"/> is set to <see cref="StreamValueType.Error"/>, contains the information about the <see cref="Exception"/> that was thrown.
+        /// </summary>
+        public Exception Error
+        {
+            get
+            {
+                if (DataType == StreamValueType.Error)
+                {
+                    return error;
+                }
+                else
+                {
+                    throw new InvalidOperationException("Cannot retrieve the value of Maybe<T>.Error if DataType is not 'Error'.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates a successful <see cref="StreamValue{T}"/> object that contains a <see cref="Result"/>.
+        /// </summary>
+        /// <param name="value">The <typeparamref name="T"/> result.</param>
+        public StreamValue(T value)
+        {
+            DataType = StreamValueType.Result;
+            result = value;
+            error = null;
+        }
+
+        /// <summary>
+        /// Creates a failed <see cref="StreamValue{T}"/> object that provides <see cref="Exception"/> information.
+        /// </summary>
+        /// <param name="ex">The <see cref="Exception"/> that was thrown.</param>
+        public StreamValue(Exception ex)
+        {
+            DataType = StreamValueType.Error;
+            result = default(T);
+            error = ex;
+        }
+    }
+
+    /// <summary>
+    /// For a <see cref="StreamValue{T}"/> produced by an <see cref="IStream{T}"/>, indicates the type of data being sent.
+    /// </summary>
+    public enum StreamValueType
+    {
+        /// <summary>
+        /// The default type contains no value or error, and simply indicates the <see cref="IStream{T}"/> has completed producing values.
+        /// </summary>
+        Completed = 0,
+        /// <summary>
+        /// This <see cref="StreamValue{T}"/> will contain a value as its <see cref="StreamValue{T}.Result"/>.
+        /// </summary>
+        Result = 1,
+        /// <summary>
+        /// An error occurred, and information can be found in <see cref="StreamValue{T}.Error"/>.
+        /// </summary>
+        Error = 2
+    }
+}

--- a/BassClefStudio.NET.Core/Streams/TakeStream.cs
+++ b/BassClefStudio.NET.Core/Streams/TakeStream.cs
@@ -17,7 +17,7 @@ namespace BassClefStudio.NET.Core.Streams
         /// <summary>
         /// The previously emitted value from <see cref="ParentStream"/>.
         /// </summary>
-        private Stack<T1> PreviousValues { get; set; }
+        private Queue<T1> PreviousValues { get; set; }
 
         /// <summary>
         /// The <see cref="int"/> number of items from the <see cref="ParentStream"/> that should be queued before/when making calls to the <see cref="ProduceFunc"/> is called to create <typeparamref name="T2"/> values.
@@ -57,7 +57,7 @@ namespace BassClefStudio.NET.Core.Streams
             if (!Started)
             {
                 Started = true;
-                PreviousValues = new Stack<T1>();
+                PreviousValues = new Queue<T1>();
                 ParentStream.ValueEmitted.AddAction(ParentValueEmitted);
                 ParentStream.Start();
             }
@@ -77,10 +77,10 @@ namespace BassClefStudio.NET.Core.Streams
             {
                 try
                 {
-                    PreviousValues.Push(e.Result);
+                    PreviousValues.Enqueue(e.Result);
                     if (PreviousValues.Count > TakeLength)
                     {
-                        PreviousValues.Pop();
+                        PreviousValues.Dequeue();
                     }
 
                     if (PreviousValues.Count == TakeLength)

--- a/BassClefStudio.NET.Core/Streams/TakeStream.cs
+++ b/BassClefStudio.NET.Core/Streams/TakeStream.cs
@@ -17,7 +17,7 @@ namespace BassClefStudio.NET.Core.Streams
         /// <summary>
         /// The previously emitted value from <see cref="ParentStream"/>.
         /// </summary>
-        private Queue<T1> PreviousValues { get; set; }
+        private Stack<T1> PreviousValues { get; set; }
 
         /// <summary>
         /// The <see cref="int"/> number of items from the <see cref="ParentStream"/> that should be queued before/when making calls to the <see cref="ProduceFunc"/> is called to create <typeparamref name="T2"/> values.
@@ -57,7 +57,7 @@ namespace BassClefStudio.NET.Core.Streams
             if (!Started)
             {
                 Started = true;
-                PreviousValues = new Queue<T1>();
+                PreviousValues = new Stack<T1>();
                 ParentStream.ValueEmitted.AddAction(ParentValueEmitted);
                 ParentStream.Start();
             }
@@ -77,10 +77,10 @@ namespace BassClefStudio.NET.Core.Streams
             {
                 try
                 {
-                    PreviousValues.Enqueue(e.Result);
+                    PreviousValues.Push(e.Result);
                     if (PreviousValues.Count > TakeLength)
                     {
-                        PreviousValues.Dequeue();
+                        PreviousValues.Pop();
                     }
 
                     if (PreviousValues.Count == TakeLength)

--- a/BassClefStudio.NET.Tests/StreamTests.cs
+++ b/BassClefStudio.NET.Tests/StreamTests.cs
@@ -115,10 +115,9 @@ namespace BassClefStudio.AppModel.Tests
             string[] values = new string[] { "wow!", "hello", "cool!", "great", "awesome!" };
             List<string> results = new List<string>();
             var stream = new SourceStream<string>(values)
-                .Where(s => s.Last() == '!')
-                .BindResult(results.Add);
+                .Where(s => s.Last() == '!');
             SetupException(stream);
-            stream.Start();
+            stream.BindResult(results.Add);
             Assert.AreEqual(3, results.Count, "Result does not contain expected number of items.");
             Assert.IsTrue(results.SequenceEqual(new string[] { values[0], values[2], values[4] }));
         }
@@ -131,10 +130,9 @@ namespace BassClefStudio.AppModel.Tests
             var source = SourceStream<string>.Repeat("Hello World!", length)
                 .Join(new SourceStream<string>(new StreamValue<string>()));
             var stream = source
-                .Aggregate<string, int>((n, s) => n + 1)
-                .BindResult(n => number = n);
+                .Aggregate<string, int>((n, s) => n + 1);
             SetupException(stream);
-            stream.Start();
+            stream.BindResult(n => number = n);
             Assert.AreEqual(length, number, "Aggregate was not expected value.");
         }
 
@@ -144,10 +142,9 @@ namespace BassClefStudio.AppModel.Tests
             int length = 8;
             int number = 0;
             var stream = SourceStream<int>.Repeat(2, length)
-                .Sum()
-                .BindResult(n => number = n);
+                .Sum();
             SetupException(stream);
-            stream.Start();
+            stream.BindResult(n => number = n);
             Assert.AreEqual(length * 2, number, "Sum was not expected value.");
         }
 
@@ -157,10 +154,9 @@ namespace BassClefStudio.AppModel.Tests
             int length = 8;
             int number = 0;
             var stream = SourceStream<string>.Repeat("Hello World!", length)
-                .Count()
-                .BindResult(n => number = n);
+                .Count();
             SetupException(stream);
-            stream.Start();
+            stream.BindResult(n => number = n);
             Assert.AreEqual(length, number, "Count was not expected value.");
         }
 
@@ -172,10 +168,9 @@ namespace BassClefStudio.AppModel.Tests
             var streamA = SourceStream<int>.CountStream(1, length);
             var streamB = new SourceStream<int>(2);
             IStream<int> join = streamB
-                .Join(streamA, (i, s) => i + s)
-                .BindResult(n => numbers.Add(n));
+                .Join(streamA, (i, s) => i + s);
             SetupException(join);
-            join.Start();
+            join.BindResult(n => numbers.Add(n));
             Assert.AreEqual(numbers.Count, length + 1, "Returned values were of an unexpected length");
             Assert.IsTrue(numbers.SequenceEqual(Enumerable.Range(2, length + 1)), "Sequence of returned values was unexpected.");
         }
@@ -187,11 +182,9 @@ namespace BassClefStudio.AppModel.Tests
             int number = 0;
             var source = SourceStream<string>.Repeat("Hello World!", length)
                 .Join(new SourceStream<string>(new StreamValue<string>()));
-            var stream = source
-                .Unique()
-                .BindResult(n => number++);
+            var stream = source.Unique();
             SetupException(stream);
-            stream.Start();
+            stream.BindResult(n => number++);
             Assert.AreEqual(1, number, "Number of unique items was invalid.");
         }
 
@@ -204,7 +197,7 @@ namespace BassClefStudio.AppModel.Tests
             Func<SourceStream<int>> recSource = () => source;
             IStream<int> stream = recSource.Rec()
                 .Count()
-                .BindResult(n => number = n);
+                .BindResult(n => number = n, false);
             source = SourceStream<int>.Repeat(1, length);
             SetupException(stream);
             stream.Start();
@@ -217,10 +210,9 @@ namespace BassClefStudio.AppModel.Tests
             int length = 4;
             int count = 0;
             SourceStream<object> source = SourceStream<object>.Repeat(new MyClass(), length);
-            IStream<MyClass> stream = source.Cast<object, MyClass>()
-                .BindResult(c => count++);
+            IStream<MyClass> stream = source.Cast<object, MyClass>();
             SetupException(stream);
-            stream.Start();
+            stream.BindResult(c => count++);
             Assert.AreEqual(count, length, "Stream casting did not correctly cast all values.");
         }
 
@@ -230,10 +222,9 @@ namespace BassClefStudio.AppModel.Tests
             int length = 4;
             int count = 0;
             SourceStream<MyClass> source = SourceStream<MyClass>.Repeat(new MyClass(), length);
-            IStream<Observable> stream = source.As<MyClass, Observable>()
-                .BindResult(c => count++); 
+            IStream<Observable> stream = source.As<MyClass, Observable>();
             SetupException(stream);
-            stream.Start();
+            stream.BindResult(c => count++);
             Assert.AreEqual(count, length, "Stream casting did not correctly cast all values.");
         }
 
@@ -243,10 +234,9 @@ namespace BassClefStudio.AppModel.Tests
             int length = 4;
             int count = 0;
             SourceStream<object> source = SourceStream<object>.Repeat(4, length);
-            IStream<MyClass> stream = source.OfType<object, MyClass>()
-                .BindResult(c => count++);
+            IStream<MyClass> stream = source.OfType<object, MyClass>();
             SetupException(stream);
-            stream.Start();
+            stream.BindResult(c => count++);
             for (int i = 0; i < length; i++)
             {
                 source.EmitValue(new MyClass());
@@ -260,10 +250,9 @@ namespace BassClefStudio.AppModel.Tests
             int length = 4;
             int sum = 0;
             SourceStream<int> source = SourceStream<int>.CountStream(1, length);
-            IStream<int> stream = source.Take((v1, v2) => v1 + v2)
-                .BindResult(c => sum += c);
+            IStream<int> stream = source.Take((v1, v2) => v1 + v2);
             SetupException(stream);
-            stream.Start();
+            stream.BindResult(c => sum += c);
             Assert.AreEqual((1 + 2) + (2 + 3) + (3 + 4), sum, "Take stream should have expected sum of all consecutive pairs of [1,2,3,4].");
         }
 
@@ -273,10 +262,9 @@ namespace BassClefStudio.AppModel.Tests
             int length = 4;
             int sum = 0;
             SourceStream<int> source = SourceStream<int>.CountStream(1, length);
-            IStream<int> stream = source.Take((vs) => vs[0] + vs[1] + vs[2], 3)
-                .BindResult(c => sum += c);
+            IStream<int> stream = source.Take((vs) => vs[0] + vs[1] + vs[2], 3);
             SetupException(stream);
-            stream.Start();
+            stream.BindResult(c => sum += c);
             Assert.AreEqual((1 + 2 + 3) + (2 + 3 + 4), sum, "Take stream should have expected sum of all consecutive triples of [1,2,3,4].");
         }
 


### PR DESCRIPTION
Includes the following enhancements:
#67 : Added the `StreamBinding<T>` class which all `IStream<T>`s now use instead of events.
#66 : Added `BindResult` extension method that uses `Select` to bind an asynchronous task with advanced event handling.
#65 : Both `BindResult` extension methods by default start the `IStream<T>` (see the optional `start` parameter).
#64 : The `Stack<T1>` collection performs first-in first-out behavior (FIFO), and thus the Take<T> documentation was adjusted to reduce confusion.

Package version updated to `v2.0.4`.