### PR TITLE
Graph data structure

### DIFF
--- a/BassClefStudio.NET.Core/BassClefStudio.NET.Core.csproj
+++ b/BassClefStudio.NET.Core/BassClefStudio.NET.Core.csproj
@@ -7,7 +7,7 @@
     <Company>BassClefStudio</Company>
     <Description>Contains helper classes and extension methods for creating .NET projects.</Description>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>2.0.4</Version>
+    <Version>2.1.0</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageProjectUrl>https://github.com/bassclefstudio/.Net-Libraries</PackageProjectUrl>
   </PropertyGroup>

--- a/BassClefStudio.NET.Core/Structures/Graph.cs
+++ b/BassClefStudio.NET.Core/Structures/Graph.cs
@@ -13,13 +13,19 @@ namespace BassClefStudio.NET.Core.Structures
     /// <typeparam name="TConnection">The type of <see cref="IConnection{T}"/> connections between <typeparamref name="TNode"/> nodes in the graph.</typeparam>
     public class Graph<TNode, TConnection> where TNode : INode where TConnection : IConnection<TNode>
     {
-        private ObservableCollection<TNode> nodes;
+        /// <summary>
+        /// The writable <see cref="Nodes"/> collection.
+        /// </summary>
+        protected ObservableCollection<TNode> nodes;
         /// <summary>
         /// The full collection of all <typeparamref name="TNode"/> nodes in the graph.
         /// </summary>
         public ReadOnlyObservableCollection<TNode> Nodes { get; }
 
-        private ObservableCollection<TConnection> connections;
+        /// <summary>
+        /// The writable <see cref="Connections"/> collection.
+        /// </summary>
+        protected ObservableCollection<TConnection> connections;
         /// <summary>
         /// The full collection of all <typeparamref name="TNode"/> nodes in the graph.
         /// </summary>
@@ -42,7 +48,7 @@ namespace BassClefStudio.NET.Core.Structures
         /// Adds a <see cref="IConnection{T}"/> and all its dependencies to the <see cref="Graph{TNode, TConnection}"/>.
         /// </summary>
         /// <param name="connection">The <typeparamref name="TConnection"/> connection to add.</param>
-        public void AddConnection(TConnection connection)
+        public virtual void AddConnection(TConnection connection)
         {
             if (!Nodes.Contains(connection.StartNode))
             {
@@ -61,7 +67,7 @@ namespace BassClefStudio.NET.Core.Structures
         /// Adds a <see cref="INode"/> and all its dependencies to the <see cref="Graph{TNode, TConnection}"/>.
         /// </summary>
         /// <param name="node">The <typeparamref name="TNode"/> node to add.</param>
-        public void AddNode(TNode node)
+        public virtual void AddNode(TNode node)
         {
             nodes.Add(node);
         }
@@ -70,7 +76,7 @@ namespace BassClefStudio.NET.Core.Structures
         /// Removes a <see cref="IConnection{T}"/> and any dependencies from the <see cref="Graph{TNode, TConnection}"/>.
         /// </summary>
         /// <param name="connection">The <typeparamref name="TConnection"/> connection to remove.</param>
-        public void RemoveConnection(TConnection connection)
+        public virtual void RemoveConnection(TConnection connection)
         {
             connections.Remove(connection);
         }
@@ -79,7 +85,7 @@ namespace BassClefStudio.NET.Core.Structures
         /// Removes a <see cref="INode"/> and any dependencies from the <see cref="Graph{TNode, TConnection}"/>.
         /// </summary>
         /// <param name="node">The <typeparamref name="TNode"/> node to remove.</param>
-        public void RemoveNode(TNode node)
+        public virtual void RemoveNode(TNode node)
         {
             nodes.Remove(node);
             foreach (var connection in connections.Where(l => l.StartNode.Equals(node) || l.EndNode.Equals(node)).ToArray())

--- a/BassClefStudio.NET.Core/Structures/Graph.cs
+++ b/BassClefStudio.NET.Core/Structures/Graph.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+
+namespace BassClefStudio.NET.Core.Structures
+{
+    /// <summary>
+    /// Represents a mathematical graph data structure, containing <typeparamref name="TNode"/> nodes connected by <typeparamref name="TConnection"/> connections.
+    /// </summary>
+    /// <typeparam name="TNode">The type of <see cref="INode"/> nodes in the graph.</typeparam>
+    /// <typeparam name="TConnection">The type of <see cref="IConnection{T}"/> connections between <typeparamref name="TNode"/> nodes in the graph.</typeparam>
+    public class Graph<TNode, TConnection> where TNode : INode where TConnection : IConnection<TNode>
+    {
+        private ObservableCollection<TNode> nodes;
+        /// <summary>
+        /// The full collection of all <typeparamref name="TNode"/> nodes in the graph.
+        /// </summary>
+        public ReadOnlyObservableCollection<TNode> Nodes { get; }
+
+        private ObservableCollection<TConnection> connections;
+        /// <summary>
+        /// The full collection of all <typeparamref name="TNode"/> nodes in the graph.
+        /// </summary>
+        public ReadOnlyObservableCollection<TConnection> Connections { get; }
+
+        /// <summary>
+        /// Creates a new, empty <see cref="Graph{TNode, TConnection}"/>.
+        /// </summary>
+        public Graph()
+        {
+            nodes = new ObservableCollection<TNode>();
+            Nodes = new ReadOnlyObservableCollection<TNode>(nodes);
+            connections = new ObservableCollection<TConnection>();
+            Connections = new ReadOnlyObservableCollection<TConnection>(connections);
+        }
+
+        #region Actions
+
+        /// <summary>
+        /// Adds a <see cref="IConnection{T}"/> and all its dependencies to the <see cref="Graph{TNode, TConnection}"/>.
+        /// </summary>
+        /// <param name="connection">The <typeparamref name="TConnection"/> connection to add.</param>
+        public void AddConnection(TConnection connection)
+        {
+            if (!Nodes.Contains(connection.StartNode))
+            {
+                AddNode(connection.StartNode);
+            }
+
+            if (!Nodes.Contains(connection.EndNode))
+            {
+                AddNode(connection.EndNode);
+            }
+
+            connections.Add(connection);
+        }
+
+        /// <summary>
+        /// Adds a <see cref="INode"/> and all its dependencies to the <see cref="Graph{TNode, TConnection}"/>.
+        /// </summary>
+        /// <param name="node">The <typeparamref name="TNode"/> node to add.</param>
+        public void AddNode(TNode node)
+        {
+            nodes.Add(node);
+        }
+
+        /// <summary>
+        /// Removes a <see cref="IConnection{T}"/> and any dependencies from the <see cref="Graph{TNode, TConnection}"/>.
+        /// </summary>
+        /// <param name="connection">The <typeparamref name="TConnection"/> connection to remove.</param>
+        public void RemoveConnection(TConnection connection)
+        {
+            connections.Remove(connection);
+        }
+
+        /// <summary>
+        /// Removes a <see cref="INode"/> and any dependencies from the <see cref="Graph{TNode, TConnection}"/>.
+        /// </summary>
+        /// <param name="node">The <typeparamref name="TNode"/> node to remove.</param>
+        public void RemoveNode(TNode node)
+        {
+            nodes.Remove(node);
+            foreach (var connection in connections.Where(l => l.StartNode.Equals(node) || l.EndNode.Equals(node)).ToArray())
+            {
+                RemoveConnection(connection);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/BassClefStudio.NET.Core/Structures/Graph.cs
+++ b/BassClefStudio.NET.Core/Structures/Graph.cs
@@ -7,6 +7,19 @@ using System.Text;
 namespace BassClefStudio.NET.Core.Structures
 {
     /// <summary>
+    /// Represents a mathematical graph data structure, containing <see cref="Node"/> nodes connected by <see cref="Connection{T}"/> connections.
+    /// </summary>
+    public class Graph : Graph<Node, Connection<Node>>
+    { }
+
+    /// <summary>
+    /// Represents a mathematical graph data structure, containing <typeparamref name="TNode"/> nodes connected by <see cref="Connection{T}"/> connections.
+    /// </summary>
+    /// <typeparam name="TNode">The type of <see cref="INode"/> nodes in the graph.</typeparam>
+    public class Graph<TNode> : Graph<TNode, Connection<TNode>> where TNode : INode
+    { }
+
+    /// <summary>
     /// Represents a mathematical graph data structure, containing <typeparamref name="TNode"/> nodes connected by <typeparamref name="TConnection"/> connections.
     /// </summary>
     /// <typeparam name="TNode">The type of <see cref="INode"/> nodes in the graph.</typeparam>
@@ -92,6 +105,76 @@ namespace BassClefStudio.NET.Core.Structures
             {
                 RemoveConnection(connection);
             }
+        }
+
+        #endregion
+        #region Queries
+
+        /// <summary>
+        /// Get all <typeparamref name="TNode"/> nodes that can be connected to the given <typeparamref name="TNode"/>.
+        /// </summary>
+        /// <param name="myNode">The <see cref="INode"/> being queried.</param>
+        /// <param name="useModes">A <see cref="bool"/> indicating whether the query should take the <see cref="IConnection{T}.Mode"/> into account.</param>
+        /// <returns>A collection of all <see cref="INode"/>s that are connected via <see cref="IConnection{T}"/>s to <paramref name="myNode"/>.</returns>
+        public IEnumerable<TNode> GetNodes(TNode myNode, bool useModes = true)
+        {
+            if (useModes)
+            {
+                return Connections.Where(c => c.Mode.HasFlag(ConnectionMode.Forwards) && c.StartNode.Equals(myNode))
+                    .Select(c => c.EndNode)
+                    .Concat(Connections.Where(c => c.Mode.HasFlag(ConnectionMode.Backwards) && c.EndNode.Equals(myNode))
+                    .Select(c => c.StartNode)).Distinct();
+            }
+            else
+            {
+                return Connections.Where(c => c.StartNode.Equals(myNode))
+                    .Select(c => c.EndNode)
+                    .Concat(Connections.Where(c => c.EndNode.Equals(myNode))
+                    .Select(c => c.StartNode)).Distinct();
+            }
+        }
+
+        /// <summary>
+        /// Get all <typeparamref name="TConnection"/> connections from a given <typeparamref name="TNode"/>.
+        /// </summary>
+        /// <param name="myNode">The <see cref="INode"/> being queried.</param>
+        /// <param name="useModes">A <see cref="bool"/> indicating whether the query should take the <see cref="IConnection{T}.Mode"/> into account.</param>
+        /// <returns>A collection of <see cref="IConnection{T}"/>s coming from <paramref name="myNode"/>.</returns>
+        public IEnumerable<TConnection> GetConnections(TNode myNode, bool useModes = true)
+        {
+            if (useModes)
+            {
+                return Connections.Where(c => c.Mode.HasFlag(ConnectionMode.Forwards) && c.StartNode.Equals(myNode))
+                    .Concat(Connections.Where(c => c.Mode.HasFlag(ConnectionMode.Backwards) && c.EndNode.Equals(myNode)))
+                    .Distinct();
+            }
+            else
+            {
+                return Connections.Where(c => c.StartNode.Equals(myNode) || c.EndNode.Equals(myNode));
+            }
+        }
+
+        /// <summary>
+        /// Uses a brute-force method to calculate the shortest <see cref="IPath{TNode, TConnection}"/> between a start and end <typeparamref name="TNode"/>.
+        /// </summary>
+        /// <param name="start">The <see cref="INode"/> to start at.</param>
+        /// <param name="end">The <see cref="INode"/> to end at.</param>
+        /// <param name="useModes">A <see cref="bool"/> indicating whether the search should take the <see cref="IConnection{T}.Mode"/> into account when building a route.</param>
+        /// <returns>The shortest <see cref="IPath{TNode, TConnection}"/> between the two nodes, or 'null' if none exists.</returns>
+        public IPath<TNode, TConnection> FindPath(TNode start, TNode end, bool useModes = true)
+        {
+            HashSet<TNode> visitedNodes = new HashSet<TNode>();
+            IPath<TNode, TConnection>[] paths = new IPath<TNode, TConnection>[] { new Path<TNode, TConnection>(start) };
+
+            while (paths.Length > 0 && !paths.Any(p => p.EndNode.Equals(end)))
+            {
+                paths = paths.SelectMany(p => GetConnections(p.EndNode, useModes)
+                    .Select(c => p.Concat(c)))
+                    .Where(p => visitedNodes.Add(p.EndNode))
+                    .ToArray();
+            }
+
+            return paths.FirstOrDefault(p => p.EndNode.Equals(end));
         }
 
         #endregion

--- a/BassClefStudio.NET.Core/Structures/IConnection.cs
+++ b/BassClefStudio.NET.Core/Structures/IConnection.cs
@@ -27,6 +27,35 @@ namespace BassClefStudio.NET.Core.Structures
     }
 
     /// <summary>
+    /// A basic <see cref="IConnection{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="INode"/> nodes this <see cref="IConnection{T}"/> connects.</typeparam>
+    public struct Connection<T> : IConnection<T> where T : INode
+    {
+        /// <inheritdoc/>
+        public T StartNode { get; }
+
+        /// <inheritdoc/>
+        public T EndNode { get; }
+
+        /// <inheritdoc/>
+        public ConnectionMode Mode { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="Connection{T}"/>.
+        /// </summary>
+        /// <param name="start">The first <typeparamref name="T"/> node this <see cref="IConnection{T}"/> connects.</param>
+        /// <param name="end">The second <typeparamref name="T"/> node this <see cref="IConnection{T}"/> connects.</param>
+        /// <param name="mode">The <see cref="ConnectionMode"/> describing how this <see cref="IConnection{T}"/> currently functions.</param>
+        public Connection(T start, T end, ConnectionMode mode = ConnectionMode.Forwards)
+        {
+            StartNode = start;
+            EndNode = end;
+            Mode = mode;
+        }
+    }
+
+    /// <summary>
     /// An enum defining the ability for a <see cref="IConnection{T}"/> to be used to navigate between two <see cref="INode"/>s.
     /// </summary>
     [Flags]

--- a/BassClefStudio.NET.Core/Structures/IConnection.cs
+++ b/BassClefStudio.NET.Core/Structures/IConnection.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BassClefStudio.NET.Core.Structures
+{
+    /// <summary>
+    /// Represents the connection between two <typeparamref name="T"/> nodes in a graph.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="INode"/> nodes this <see cref="IConnection{T}"/> connects.</typeparam>
+    public interface IConnection<out T> where T : INode
+    {
+        /// <summary>
+        /// The first <typeparamref name="T"/> node this <see cref="IConnection{T}"/> connects.
+        /// </summary>
+        T StartNode { get; }
+
+        /// <summary>
+        /// The second <typeparamref name="T"/> node this <see cref="IConnection{T}"/> connects.
+        /// </summary>
+        T EndNode { get; }
+
+        /// <summary>
+        /// The <see cref="ConnectionMode"/> describing how this <see cref="IConnection{T}"/> currently functions.
+        /// </summary>
+        ConnectionMode Mode { get; }
+    }
+
+    /// <summary>
+    /// An enum defining the ability for a <see cref="IConnection{T}"/> to be used to navigate between two <see cref="INode"/>s.
+    /// </summary>
+    [Flags]
+    public enum ConnectionMode
+    {
+        /// <summary>
+        /// The <see cref="IConnection{T}"/> is closed and no connection can currently be made.
+        /// </summary>
+        Closed = 0,
+
+        /// <summary>
+        /// Connection can be made from the <see cref="IConnection{T}.StartNode"/> to the <see cref="IConnection{T}.EndNode"/>.
+        /// </summary>
+        Forwards = 1,
+
+        /// <summary>
+        /// Connection can be made from the <see cref="IConnection{T}.EndNode"/> to the <see cref="IConnection{T}.StartNode"/>.
+        /// </summary>
+        Backwards = 2,
+
+        /// <summary>
+        /// Connection can be made in either direction between <see cref="IConnection{T}.StartNode"/> and <see cref="IConnection{T}.EndNode"/>.
+        /// </summary>
+        Both = Forwards | Backwards
+    }
+}

--- a/BassClefStudio.NET.Core/Structures/INode.cs
+++ b/BassClefStudio.NET.Core/Structures/INode.cs
@@ -8,6 +8,41 @@ namespace BassClefStudio.NET.Core.Structures
     /// Represents a single identifiable node in a graph.
     /// </summary>
     public interface INode : IIdentifiable<string>, IEquatable<INode>
+    { }
+
+    /// <summary>
+    /// A basic <see cref="INode"/> containing only a <see cref="string"/> ID.
+    /// </summary>
+    public struct Node : INode
     {
+        /// <inheritdoc/>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Creates a new <see cref="Node"/>.
+        /// </summary>
+        /// <param name="id">The <see cref="Node"/>'s <see cref="string"/> ID.</param>
+        public Node(string id)
+        {
+            Id = id;
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            return obj is Node node && Equals(node);
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(INode other)
+        {
+            return other is Node node && Equals(node);
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(Node other)
+        {
+            return Id == other.Id;
+        }
     }
 }

--- a/BassClefStudio.NET.Core/Structures/INode.cs
+++ b/BassClefStudio.NET.Core/Structures/INode.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BassClefStudio.NET.Core.Structures
+{
+    /// <summary>
+    /// Represents a single identifiable node in a graph.
+    /// </summary>
+    public interface INode : IIdentifiable<string>, IEquatable<INode>
+    {
+    }
+}

--- a/BassClefStudio.NET.Core/Structures/IPath.cs
+++ b/BassClefStudio.NET.Core/Structures/IPath.cs
@@ -50,5 +50,32 @@ namespace BassClefStudio.NET.Core.Structures
                 return false;
             }
         }
+
+        /// <summary>
+        /// Gets the <see cref="ConnectionMode"/> mode that can be applied to the given <see cref="IPath{TNode, TConnection}"/> as a whole.
+        /// </summary>
+        /// <typeparam name="TNode">The type of <see cref="INode"/> nodes this <see cref="IPath{TNode, TConnection}"/> links.</typeparam>
+        /// <typeparam name="TConnection">The type of <see cref="IConnection{T}"/> connections this <see cref="IPath{TNode, TConnection}"/> traverses.</typeparam>
+        /// <param name="path">The <see cref="IPath{TNode, TConnection}"/> path to check.</param>
+        /// <returns>A <see cref="ConnectionMode"/> indicating how the <paramref name="path"/> is traversable.</returns>
+        public static ConnectionMode GetConnectionMode<TNode, TConnection>(this IPath<TNode, TConnection> path) where TNode : INode where TConnection : IConnection<TNode>
+        {
+            if(path.Connections.All(c => c.Mode == ConnectionMode.Both))
+            {
+                return ConnectionMode.Both;
+            }
+            else if (path.Connections.All(c => c.Mode.HasFlag(ConnectionMode.Forwards)))
+            {
+                return ConnectionMode.Forwards;
+            }
+            else if (path.Connections.All(c => c.Mode.HasFlag(ConnectionMode.Backwards)))
+            {
+                return ConnectionMode.Backwards;
+            }
+            else
+            {
+                return ConnectionMode.Closed;
+            }
+        }
     }
 }

--- a/BassClefStudio.NET.Core/Structures/IPath.cs
+++ b/BassClefStudio.NET.Core/Structures/IPath.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace BassClefStudio.NET.Core.Structures
+{
+    /// <summary>
+    /// Represents a description of a path along a collection of <typeparamref name="TConnection"/> connections that links a group of <typeparamref name="TNode"/> nodes in a graph.
+    /// </summary>
+    /// <typeparam name="TNode">The type of <see cref="INode"/> nodes this <see cref="IPath{TNode, TConnection}"/> links.</typeparam>
+    /// <typeparam name="TConnection">The type of <see cref="IConnection{T}"/> connections this <see cref="IPath{TNode, TConnection}"/> traverses.</typeparam>
+    public interface IPath<out TNode, out TConnection> where TNode : INode where TConnection : IConnection<TNode>
+    {
+        /// <summary>
+        /// The ordered collection of <typeparamref name="TConnection"/> connections that make up this contiguous <see cref="IPath{TNode, TConnection}"/>.
+        /// </summary>
+        IEnumerable<TConnection> Connections { get; }
+    }
+
+    /// <summary>
+    /// Extension methods for managing and manipulating <see cref="IPath{TNode, TConnection}"/>s in a graph.
+    /// </summary>
+    public static class PathExtensions
+    {
+        /// <summary>
+        /// Checks if the <paramref name="path"/> is continuous and connects two valid <typeparamref name="TNode"/> nodes.
+        /// </summary>
+        /// <typeparam name="TNode">The type of <see cref="INode"/> nodes this <see cref="IPath{TNode, TConnection}"/> links.</typeparam>
+        /// <typeparam name="TConnection">The type of <see cref="IConnection{T}"/> connections this <see cref="IPath{TNode, TConnection}"/> traverses.</typeparam>
+        /// <param name="path">The <see cref="IPath{TNode, TConnection}"/> path to check.</param>
+        /// <returns>A <see cref="bool"/> indicating whether <paramref name="path"/> is continuous.</returns>
+        public static bool Validate<TNode, TConnection>(this IPath<TNode, TConnection> path) where TNode : INode where TConnection : IConnection<TNode>
+        {
+            if (path.Connections.Any())
+            {
+                TNode currentNode = path.Connections.First().StartNode;
+                foreach (var c in path.Connections)
+                {
+                    if (!currentNode.Equals(c.StartNode))
+                    {
+                        return false;
+                    }
+                    currentNode = c.EndNode;
+                }
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/BassClefStudio.NET.Tests/GraphTests.cs
+++ b/BassClefStudio.NET.Tests/GraphTests.cs
@@ -1,0 +1,201 @@
+﻿using BassClefStudio.NET.Core.Structures;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BassClefStudio.NET.Tests
+{
+    [TestClass]
+    public class GraphTests
+    {
+        [TestMethod]
+        public void TestCreateGraphC()
+        {
+            Graph testGraph = new Graph();
+            Node[] nodes = new Node[]
+            {
+                new Node("0"),
+                new Node("1"),
+                new Node("2"),
+                new Node("3"),
+                new Node("4")
+            };
+
+            Connection<Node>[] connections = new Connection<Node>[]
+            {
+                new Connection<Node>(nodes[0], nodes[1]),
+                new Connection<Node>(nodes[1], nodes[2]),
+                new Connection<Node>(nodes[2], nodes[3]),
+                new Connection<Node>(nodes[3], nodes[4])
+            };
+
+            foreach (var connection in connections)
+            {
+                testGraph.AddConnection(connection);
+            }
+
+            Assert.AreEqual(nodes.Length, testGraph.Nodes.Count, "Incorrect number of nodes found in graph.");
+            Assert.AreEqual(connections.Length, testGraph.Connections.Count, "Incorrect number of connections found in graph.");
+
+            foreach (var connection in connections)
+            {
+                testGraph.RemoveConnection(connection);
+            }
+
+            Assert.AreEqual(nodes.Length, testGraph.Nodes.Count, "Incorrect number of nodes found in graph after connections removed.");
+            Assert.AreEqual(0, testGraph.Connections.Count, "Expected all connections removed.");
+
+            foreach (var node in nodes)
+            {
+                testGraph.RemoveNode(node);
+            }
+
+            Assert.AreEqual(0, testGraph.Nodes.Count, "Expected all nodes removed.");
+            Assert.AreEqual(0, testGraph.Connections.Count, "Expected all connections removed.");
+        }
+
+        [TestMethod]
+        public void TestCreateGraphN()
+        {
+            Graph testGraph = new Graph();
+            Node[] nodes = new Node[]
+            {
+                new Node("0"),
+                new Node("1"),
+                new Node("2"),
+                new Node("3"),
+                new Node("4")
+            };
+
+            Connection<Node>[] connections = new Connection<Node>[]
+            {
+                new Connection<Node>(nodes[0], nodes[1]),
+                new Connection<Node>(nodes[1], nodes[2]),
+                new Connection<Node>(nodes[2], nodes[3]),
+                new Connection<Node>(nodes[3], nodes[4])
+            };
+
+            foreach (var node in nodes)
+            {
+                testGraph.AddNode(node);
+            }
+
+            Assert.AreEqual(nodes.Length, testGraph.Nodes.Count, "Incorrect number of nodes found in graph.");
+
+            foreach (var connection in connections)
+            {
+                testGraph.AddConnection(connection);
+            }
+
+            Assert.AreEqual(nodes.Length, testGraph.Nodes.Count, "Incorrect number of nodes found in graph.");
+            Assert.AreEqual(connections.Length, testGraph.Connections.Count, "Incorrect number of connections found in graph.");
+
+            foreach (var node in nodes)
+            {
+                testGraph.RemoveNode(node);
+            }
+
+            Assert.AreEqual(0, testGraph.Nodes.Count, "Expected all nodes removed.");
+            Assert.AreEqual(0, testGraph.Connections.Count, "Expected all connections removed.");
+        }
+
+        [TestMethod]
+        public void TestCreatePath()
+        {
+            Node[] nodes = new Node[]
+            {
+                new Node("0"),
+                new Node("1"),
+                new Node("2"),
+                new Node("3"),
+                new Node("4")
+            };
+
+            Connection<Node>[] connections = new Connection<Node>[]
+            {
+                new Connection<Node>(nodes[0], nodes[1]),
+                new Connection<Node>(nodes[1], nodes[2]),
+                new Connection<Node>(nodes[2], nodes[3]),
+                new Connection<Node>(nodes[3], nodes[4])
+            };
+
+            Path<Node, Connection<Node>> path = new Path<Node, Connection<Node>>(nodes[0], connections);
+            Assert.AreEqual(nodes[4], path.EndNode, "Incorrect calculated end node.");
+            Assert.AreEqual(ConnectionMode.Forwards, path.GetConnectionMode(), "Incorrect calculated connection mode.");
+        }
+
+        [TestMethod]
+        public void TestFindPath()
+        {
+            Graph testGraph = new Graph();
+            Node[] nodes = new Node[]
+            {
+                new Node("0"),
+                new Node("1"),
+                new Node("2"),
+                new Node("3"),
+                new Node("4")
+            };
+
+            Connection<Node>[] connections = new Connection<Node>[]
+            {
+                new Connection<Node>(nodes[0], nodes[1]),
+                new Connection<Node>(nodes[1], nodes[2]),
+                new Connection<Node>(nodes[2], nodes[3]),
+                new Connection<Node>(nodes[3], nodes[4]),
+                new Connection<Node>(nodes[1], nodes[4])
+            };
+
+            foreach (var connection in connections)
+            {
+                testGraph.AddConnection(connection);
+            }
+
+            var path = testGraph.FindPath(nodes[0], nodes[4]);
+            Assert.IsNotNull(path, "Path between nodes not found.");
+            Assert.AreEqual(nodes[0], path.StartNode, "Incorrect path start node.");
+            Assert.AreEqual(nodes[0], path.StartNode, "Incorrect path end node.");
+            Assert.AreEqual(2, path.Connections.Count(), "Number of connections was not optimal value.");
+            Assert.AreEqual(ConnectionMode.Forwards, path.GetConnectionMode(), "Incorrect calculated connection mode.");
+        }
+
+        [TestMethod]
+        public void PathNotExist()
+        {
+            Graph testGraph = new Graph();
+            Node[] nodes = new Node[]
+            {
+                new Node("0"),
+                new Node("1"),
+                new Node("2"),
+                new Node("3"),
+                new Node("4")
+            };
+
+            Connection<Node>[] connections = new Connection<Node>[]
+            {
+                new Connection<Node>(nodes[0], nodes[1]),
+                new Connection<Node>(nodes[1], nodes[2]),
+                new Connection<Node>(nodes[3], nodes[2]),
+                new Connection<Node>(nodes[3], nodes[4]),
+            };
+
+            foreach (var connection in connections)
+            {
+                testGraph.AddConnection(connection);
+            }
+
+            var path1 = testGraph.FindPath(nodes[0], nodes[4]);
+            Assert.IsNull(path1, "Path between nodes found, but does not exist.");
+            var path2 = testGraph.FindPath(nodes[0], nodes[4], false);
+            Assert.IsNotNull(path2, "Indiscriminate path between nodes not found.");
+            Assert.AreEqual(nodes[0], path2.StartNode, "Incorrect path start node.");
+            Assert.AreEqual(nodes[0], path2.StartNode, "Incorrect path end node.");
+            Assert.AreEqual(4, path2.Connections.Count(), "Number of connections was not optimal value.");
+            Assert.AreEqual(ConnectionMode.Closed, path2.GetConnectionMode(), "Incorrect calculated connection mode.");
+        }
+    }
+}

--- a/BassClefStudio.NET.Tests/StreamTests.cs
+++ b/BassClefStudio.NET.Tests/StreamTests.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BassClefStudio.AppModel.Tests
+namespace BassClefStudio.NET.Tests
 {
     [TestClass]
     public class StreamTests


### PR DESCRIPTION
Added a basic, generic implementation of the mathematical **graph** - `Graph<TNode, TConnection>`.

It allows for basic methods to be provided for any data that matches the structure of connected nodes and implements the `INode` and `IConnection<T>` interfaces. It also includes default implementations (`Node` and `Connection<T>`) for representing basic graphs of data. These basic types are used for unit tests that check to make sure the graph performs as expected.