### PR TITLE
Minor improvements to graph and path, including additional constructors

### DIFF
--- a/BassClefStudio.NET.Core/BassClefStudio.NET.Core.csproj
+++ b/BassClefStudio.NET.Core/BassClefStudio.NET.Core.csproj
@@ -7,7 +7,7 @@
     <Company>BassClefStudio</Company>
     <Description>Contains helper classes and extension methods for creating .NET projects.</Description>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>2.1.0</Version>
+    <Version>2.1.2</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageProjectUrl>https://github.com/bassclefstudio/.Net-Libraries</PackageProjectUrl>
   </PropertyGroup>

--- a/BassClefStudio.NET.Core/Structures/Graph.cs
+++ b/BassClefStudio.NET.Core/Structures/Graph.cs
@@ -24,7 +24,7 @@ namespace BassClefStudio.NET.Core.Structures
     /// </summary>
     /// <typeparam name="TNode">The type of <see cref="INode"/> nodes in the graph.</typeparam>
     /// <typeparam name="TConnection">The type of <see cref="IConnection{T}"/> connections between <typeparamref name="TNode"/> nodes in the graph.</typeparam>
-    public class Graph<TNode, TConnection> where TNode : INode where TConnection : IConnection<TNode>
+    public class Graph<TNode, TConnection> : Observable where TNode : INode where TConnection : IConnection<TNode>
     {
         /// <summary>
         /// The writable <see cref="Nodes"/> collection.

--- a/BassClefStudio.NET.Core/Structures/IPath.cs
+++ b/BassClefStudio.NET.Core/Structures/IPath.cs
@@ -23,7 +23,7 @@ namespace BassClefStudio.NET.Core.Structures
     /// </summary>
     /// <typeparam name="TNode">The type of <see cref="INode"/> nodes this <see cref="IPath{TNode, TConnection}"/> links.</typeparam>
     /// <typeparam name="TConnection">The type of <see cref="IConnection{T}"/> connections this <see cref="IPath{TNode, TConnection}"/> traverses.</typeparam>
-    public class Path<TNode, TConnection> : IPath<TNode, TConnection> where TNode : INode where TConnection : IConnection<TNode>
+    public class Path<TNode, TConnection> : Observable, IPath<TNode, TConnection> where TNode : INode where TConnection : IConnection<TNode>
     {
         /// <inheritdoc/>
         public IEnumerable<TConnection> Connections { get; }
@@ -88,6 +88,36 @@ namespace BassClefStudio.NET.Core.Structures
         /// <param name="start">The <typeparamref name="TNode"/> node this <see cref="IPath{TNode, TConnection}"/> starts at.</param>
         /// <param name="connections">The ordered collection of <typeparamref name="TConnection"/> connections that make up this contiguous <see cref="IPath{TNode, TConnection}"/>.</param>
         public Path(TNode start, params TConnection[] connections) : this(start, (IEnumerable<TConnection>)connections)
+        { }
+
+        /// <summary>
+        /// Creates a new <see cref="Path{TNode, TConnection}"/> and calculates <see cref="StartNode"/> and <see cref="EndNode"/> automatically.
+        /// </summary>
+        /// <param name="connections">The ordered collection of <typeparamref name="TConnection"/> connections that make up this contiguous <see cref="IPath{TNode, TConnection}"/>.</param>
+        public Path(IEnumerable<TConnection> connections)
+        {
+            Connections = connections;
+            if(!Connections.Any())
+            {
+                throw new ArgumentException("The connections collection must have at least one connection if no start or end is specified.", "connections");
+            }
+            else
+            {
+                StartNode = Connections.First().StartNode;
+                EndNode = this.FindEnd();
+                if (!this.Validate())
+                {
+                    throw new ArgumentException("The provided connections do not link the two nodes.", "connections");
+                }
+                Mode = this.GetConnectionMode();
+            }
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Path{TNode, TConnection}"/> and calculates <see cref="StartNode"/> and <see cref="EndNode"/> automatically.
+        /// </summary>
+        /// <param name="connections">The ordered collection of <typeparamref name="TConnection"/> connections that make up this contiguous <see cref="IPath{TNode, TConnection}"/>.</param>
+        public Path(params TConnection[] connections) : this((IEnumerable<TConnection>)connections)
         { }
     }
 

--- a/BassClefStudio.NET.Tests/GraphTests.cs
+++ b/BassClefStudio.NET.Tests/GraphTests.cs
@@ -122,9 +122,18 @@ namespace BassClefStudio.NET.Tests
                 new Connection<Node>(nodes[3], nodes[4])
             };
 
-            Path<Node, Connection<Node>> path = new Path<Node, Connection<Node>>(nodes[0], connections);
-            Assert.AreEqual(nodes[4], path.EndNode, "Incorrect calculated end node.");
-            Assert.AreEqual(ConnectionMode.Forwards, path.GetConnectionMode(), "Incorrect calculated connection mode.");
+            Path<Node, Connection<Node>>[] paths = new Path<Node, Connection<Node>>[]
+            {
+                new Path<Node, Connection<Node>>(nodes[0], connections),
+                new Path<Node, Connection<Node>>(nodes[0], nodes[4], connections),
+                new Path<Node, Connection<Node>>(connections),
+            };
+
+            foreach (var path in paths)
+            {
+                Assert.AreEqual(nodes[4], path.EndNode, "Incorrect calculated end node.");
+                Assert.AreEqual(ConnectionMode.Forwards, path.GetConnectionMode(), "Incorrect calculated connection mode.");
+            }
         }
 
         [TestMethod]


### PR DESCRIPTION
Additionally `Graph` and `Path` (concrete) inherit from `Observable`, which allows for more effective implementations.